### PR TITLE
D 02247 metadata model

### DIFF
--- a/src/main/webapp/app/controllers/irContextController.js
+++ b/src/main/webapp/app/controllers/irContextController.js
@@ -83,6 +83,13 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
       $scope.closeModal();
     };
 
+    $scope.resetAddMetadataModal = function() {
+      $scope.irForm.addMetadata.$setPristine(); 
+      $scope.irForm.addMetadata.entries.length = 0;
+      $scope.irForm.addMetadata.entries.push({});
+      $scope.closeModal();
+    };
+
     $scope.addMetadata = function (form) {
       $scope.submitClicked = true;
 
@@ -96,9 +103,10 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
       });
 
       $scope.context.createMetadata(triples).then(function () {
-        $scope.closeModal();
+        $scope.resetAddMetadataModal();
         $scope.submitClicked = false;
       });
+      
     };
 
     $scope.cancelDeleteIrContext = function (irContext) {

--- a/src/main/webapp/app/views/modals/addMetadataModal.html
+++ b/src/main/webapp/app/views/modals/addMetadataModal.html
@@ -62,7 +62,7 @@
 
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-default" ng-class="{'btn-warning': irForm.addMetadata.$dirty}" ng-click="closeModal()">Cancel</button>
+      <button type="button" class="btn btn-default" ng-class="{'btn-warning': irForm.addMetadata.$dirty}" ng-click="resetAddMetadataModal()">Cancel</button>
       <button type="submit" class="btn btn-success" ng-disabled="irForm.addMetadata.$invalid || submitClicked">Add</button>
     </div>
 </form>

--- a/src/main/webapp/app/views/modals/addMetadataModal.html
+++ b/src/main/webapp/app/views/modals/addMetadataModal.html
@@ -1,6 +1,6 @@
 <form class="add-metadata-model" name="irForm.addMetadata" ng-submit="addMetadata(irForm.addMetadata)" novalidate ng-init="irForm.addMetadata.entries=[]">
     <div class="modal-header {{attr.modalHeaderClass}}">
-      <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelDeleteIr()"><span aria-hidden="true">&times;</span></button>
+      <button type="button" class="close modal-close" aria-label="Close" ng-click="resetAddMetadataModal()"><span aria-hidden="true">&times;</span></button>
       <h4 class="modal-title">Add Metadata</h4>
     </div>
     <div class="modal-body" ng-init="irForm.addMetadata.entries=[{label:'',value:''}]">


### PR DESCRIPTION
Resolves Issue D-02247: Add metadata modal does not clear on close, cancel or create.

This adds a reset method that is called upon creation, cancel and modal close. The reset method resets the entries to an empty object, sets the form to pristine and closes the modal.