### PR TITLE
[B03709] Copy iiif manifest uri to clipboard option when available

### DIFF
--- a/src/main/webapp/app/config/appConfig.js
+++ b/src/main/webapp/app/config/appConfig.js
@@ -36,6 +36,8 @@ var appConfig = {
     'contentMap': {"image": ["image/jpeg","image/png","image/gif"],"seadragon": ["image/jp2","image/tiff"]},
 
     'cantaloupeBaseUrl': 'https://api-dev.library.tamu.edu/iiif/2/',
-    'fedoraPath': '/fcrepo/rest/'
+    'fedoraPath': '/fcrepo/rest/',
+
+    'iiifServiceUrl': 'https://api-dev.library.tamu.edu/iiif-service/'
 
 };

--- a/src/main/webapp/app/controllers/irContextController.js
+++ b/src/main/webapp/app/controllers/irContextController.js
@@ -1,4 +1,4 @@
-cap.controller("IrContextController", function ($controller, $location, $routeParams, $scope, $filter, IRRepo) {
+cap.controller("IrContextController", function ($controller, $location, $routeParams, $scope, $filter, $timeout, IRRepo) {
 
   angular.extend(this, $controller('CoreAdminController', {
     $scope: $scope
@@ -227,6 +227,54 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
     $scope.canPreview = function(fileType) {
         var previewable = ['image/png','image/jpeg','image/gif','image/bmp'];
         return (previewable.indexOf(fileType) !== -1);
+    };
+
+    $scope.getIIIFUrl = function() {
+      if (typeof appConfig.iiifServiceUrl !== 'undefined') {
+        var contextProperties = [];
+        var iiifUri = null;
+
+        if ($scope.context.resource && $scope.context.hasParent) {
+          var parentContext = $scope.context.ir.getContext($scope.context.parent.object);
+          if (parentContext.hasParent) {
+            var grandParentContext = $scope.context.ir.getContext(parentContext.parent.object);
+            contextProperties = grandParentContext.properties;
+            iiifUri = grandParentContext.uri;
+          }
+        } else {
+          contextProperties = $scope.context.properties;
+          iiifUri = $scope.context.uri;
+        }
+
+        if (iiifUri && contextProperties) {
+          var hasManifest = false;
+          var hasFile = false;
+          var isPCDM = false;
+          for (var i in contextProperties) {
+            var triple = contextProperties[i];
+            if (!hasFile) {
+              if (triple.predicate.indexOf("#hasFile") !== -1) {
+                hasFile = true;
+              }
+            }
+            if (!isPCDM) {
+              if (triple.predicate.indexOf("#type") !== -1) {
+                  if (triple.object === "http://pcdm.org/models#Object") {
+                    isPCDM = true;
+                  }
+              }
+            }
+            if (isPCDM && hasFile) {
+              hasManifest = true;
+              break;
+            }
+          }
+          if (hasManifest) {
+            return appConfig.iiifServiceUrl+$scope.ir.type.toLowerCase()+"/presentation/"+iiifUri.replace($scope.ir.rootUri,"");
+          }
+        }
+      }
+      return null;
     };
 
     $scope.resetCreateContainer();

--- a/src/main/webapp/app/views/irContext.html
+++ b/src/main/webapp/app/views/irContext.html
@@ -19,6 +19,7 @@
         <li role="menuitem" class="disabled"><a href="#"><span class="glyphicon glyphicon-random"></span> Migrate</a></li>
         <li role="menuitem" class="disabled"><a href="#"><span class="glyphicon glyphicon-export"></span> Export</a></li>
         <li role="menuitem bg-danger" ng-click="openModal('#irContextDeleteModal')"><a href="#" class="bg-danger"><span class="glyphicon glyphicon-trash"></span> Delete</a></li>
+        <li ng-if="!context.resource && getIIIFUrl()" role="menuitem"><a href="" ng-click="copyToClipboard(getIIIFUrl(), 'IIIFUrl')">Copy IIIF Manifest URL</a></li>
 
         <li class="divider"></li>
         <li class="dropdown-header">Resource Actions</li>
@@ -101,6 +102,7 @@
                     <li role="menuitem" class="disabled"><a href="#">Create thumbnail</a></li>
                     <li role="menuitem" class="disabled"><a href="#">View in Mirador</a></li>
                     <li role="menuitem"><a href="" ng-click="copyToClipboard(context.uri, 'contextUri')">Copy Resource URL</a></li>
+                    <li ng-if="getIIIFUrl()" role="menuitem"><a href="" ng-click="copyToClipboard(getIIIFUrl(), 'contextUri')">Copy IIIF Manifest URL</a></li>
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
- Adds a 'Copy IIIF Manifest URL' option to 'Context Actions' for containers with a '#hasFile' property and 'http://pcdm.org/models#Object' type.

- Adds a 'Copy IIIF Manifest URL' option to the hamburger dropdown for resources with a grandparent with a '#hasFile' property and 'http://pcdm.org/models#Object' type.

- This PR adds an 'iiifServiceUrl' property to appConfig.js that will need to be templated for deployment.