### PR TITLE
Fixed cut and paste mistakes on modals

### DIFF
--- a/src/main/webapp/app/views/modals/commitTransactionModal.html
+++ b/src/main/webapp/app/views/modals/commitTransactionModal.html
@@ -1,5 +1,5 @@
 <div class="modal-header {{attr.modalHeaderClass}}">
-  <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelDeleteIrContext()"><span aria-hidden="true">&times;</span></button>
+  <button type="button" class="close modal-close" aria-label="Close" ng-click="closeModal()"><span aria-hidden="true">&times;</span></button>
   <h4 class="modal-title">Confirm Commit</h4>
 </div>
 <div class="modal-body">

--- a/src/main/webapp/app/views/modals/rollbackTransactionModal.html
+++ b/src/main/webapp/app/views/modals/rollbackTransactionModal.html
@@ -1,5 +1,5 @@
 <div class="modal-header {{attr.modalHeaderClass}}">
-    <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelDeleteIrContext()"><span aria-hidden="true">&times;</span></button>
+    <button type="button" class="close modal-close" aria-label="Close" ng-click="closeModal()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Confirm Rollback</h4>
   </div>
   <div class="modal-body">

--- a/src/main/webapp/app/views/modals/versionsModal.html
+++ b/src/main/webapp/app/views/modals/versionsModal.html
@@ -1,6 +1,6 @@
 <form name="createVersion">
 <div class="modal-header {{attr.modalHeaderClass}}">
-    <button type="button" class="close modal-close" aria-label="Close" ng-click="resetCreateContainer()"><span aria-hidden="true">&times;</span></button>
+    <button type="button" class="close modal-close" aria-label="Close" ng-click="closeModal()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Versions</h4>
 </div>
 <div class="modal-body">


### PR DESCRIPTION
Resolves DEFECT D-01244: Ensure all modals close properly with cancel or top right x.

Several of the modals had cut and paste type errors with references to modal close and reset methods that were not available in their current scope. These were changed to use the more general closeModal method.