### PR TITLE
[D-01246] Inline edit of metadata does not validate, allows saving empty value.

### DIFF
--- a/src/main/webapp/app/controllers/irContextController.js
+++ b/src/main/webapp/app/controllers/irContextController.js
@@ -50,13 +50,13 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
 
     $scope.updateMetadatum = function(triple, newValue) {
       var defer = $q.defer();
-      var pomise = defer.promise;
+      var promise = defer.promise;
       if(newValue && (newValue.length === 0 || newValue !== "\"\"")) {
-        pomise = $scope.context.updateMetadatum(triple, newValue);
+        promise = $scope.context.updateMetadatum(triple, newValue);
       } else {
         defer.reject("Update Rejected: Value was empty.");
       }
-      return pomise;
+      return promise;
     };
 
     $scope.advancedUpdate = function (sparql) {

--- a/src/main/webapp/app/controllers/irContextController.js
+++ b/src/main/webapp/app/controllers/irContextController.js
@@ -1,4 +1,4 @@
-cap.controller("IrContextController", function ($controller, $location, $routeParams, $scope, $timeout, $filter, IRRepo, FixityReport) {
+cap.controller("IrContextController", function ($controller, $location, $routeParams, $scope, $timeout, $filter, $q, IRRepo, FixityReport) {
 
   angular.extend(this, $controller('CoreAdminController', {
     $scope: $scope
@@ -46,6 +46,17 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
         $scope.closeModal();
         $scope.submitClicked = false;
       });
+    };
+
+    $scope.updateMetadatum = function(triple, newValue) {
+      var defer = $q.defer();
+      var pomise = defer.promise;
+      if(newValue && (newValue.length === 0 || newValue !== "\"\"")) {
+        pomise = $scope.context.updateMetadatum(triple, newValue);
+      } else {
+        defer.reject("Update Rejected: Value was empty.");
+      }
+      return pomise;
     };
 
     $scope.advancedUpdate = function (sparql) {

--- a/src/main/webapp/app/directives/irSectionDirective.js
+++ b/src/main/webapp/app/directives/irSectionDirective.js
@@ -52,6 +52,8 @@ cap.directive("irsection", function($controller, $timeout, IrSectionService) {
             $scope.editWorking = true;
             $scope.editAction(argObj).then(function() {
               $scope.editWorking = false;
+            }, function(reason) {
+              console.warn(reason);
             });
           };
 

--- a/src/main/webapp/app/views/irContext.html
+++ b/src/main/webapp/app/views/irContext.html
@@ -143,7 +143,7 @@
         list="context.metadata"
         list-element-action="ir.loadContext(le)"
         add-action="openModal('#addMetadata')"
-        edit-action="context.updateMetadatum(triple,newObject)"
+        edit-action="updateMetadatum(triple,newObject)"
         remove-action="context.removeMetadata(items)">
         <br ng-show="contentExpanded">
         <dl ng-show="contentExpanded" class="dl-horizontal" ng-repeat="triple in list | unique:'predicate'">


### PR DESCRIPTION
Resolves D-01246: Inline edit of metadata does not validate, allows saving empty value.

Added a controller method to validate inline edits of metadata for empty values.