### PR TITLE
[D-01241] IR edit/create password should be input type password

### DIFF
--- a/src/main/webapp/app/views/modals/createIRModal.html
+++ b/src/main/webapp/app/views/modals/createIRModal.html
@@ -68,7 +68,6 @@
               </validatedinput>
 
               <validatedinput
-                id="createPassword"
                 model="irToCreate"
                 property="password"
                 label="Password"

--- a/src/main/webapp/app/views/modals/createIRModal.html
+++ b/src/main/webapp/app/views/modals/createIRModal.html
@@ -21,7 +21,8 @@
               placeholder="Type of the new IR"
               form="irForms.create"
               validations="irForms.validations"
-              results="irForms.getResults()">
+              results="irForms.getResults()"
+              no-id="true">
             </validatedselect>
 
             <validatedinput
@@ -32,7 +33,8 @@
               form="irForms.create"
               validations="irForms.validations"
               results="irForms.getResults()"
-              autocomplete="off">
+              autocomplete="off"
+              no-id="true">
             </validatedinput>
 
             <validatedinput
@@ -43,7 +45,8 @@
               form="irForms.create"
               validations="irForms.validations"
               results="irForms.getResults()"
-              autocomplete="off">
+              autocomplete="off"
+              no-id="true">
             </validatedinput>
           </div>
         </div>
@@ -60,10 +63,12 @@
                 form="irForms.create"
                 validations="irForms.validations"
                 results="irForms.getResults()"
-                autocomplete="off">
+                autocomplete="off"
+                no-id="true">
               </validatedinput>
 
               <validatedinput
+                id="createPassword"
                 model="irToCreate"
                 property="password"
                 label="Password"
@@ -71,7 +76,9 @@
                 form="irForms.create"
                 validations="irForms.validations"
                 results="irForms.getResults()"
-                autocomplete="off">
+                autocomplete="off"
+                type="password"
+                no-id="true">
               </validatedinput>
           </div>
         </div>

--- a/src/main/webapp/app/views/modals/irEditModal.html
+++ b/src/main/webapp/app/views/modals/irEditModal.html
@@ -21,7 +21,8 @@
                     placeholder="Type of the new IR"
                     form="irForms.edit"
                     validations="irForms.validations"
-                    results="irForms.getResults()">
+                    results="irForms.getResults()"
+                    no-id="true">
                   </validatedselect>
                   <validatedinput
                     model="irToEdit"
@@ -31,7 +32,8 @@
                     form="irForms.edit"
                     validations="irForms.validations"
                     results="irForms.getResults()"
-                    autocomplete="off">
+                    autocomplete="off"
+                    no-id="true">
                   </validatedinput>
                   <validatedinput
                     model="irToEdit"
@@ -41,7 +43,8 @@
                     form="irForms.edit"
                     validations="irForms.validations"
                     results="irForms.getResults()"
-                    autocomplete="off">
+                    autocomplete="off"
+                    no-id="true">
                   </validatedinput>
                 </div>
             </div>
@@ -57,7 +60,8 @@
                         form="irForms.create"
                         validations="irForms.validations"
                         results="irForms.getResults()"
-                        autocomplete="off">
+                        autocomplete="off"
+                        no-id="true">
                     </validatedinput>
 
                     <validatedinput
@@ -68,7 +72,9 @@
                         form="irForms.create"
                         validations="irForms.validations"
                         results="irForms.getResults()"
-                        autocomplete="off">
+                        autocomplete="off"
+                        type="password"
+                        no-id="true">
                     </validatedinput>
                 </div>
             </div>


### PR DESCRIPTION
Resolves D-01241: IR edit/create password should be input type password

Added type 'password' to password inputs on ir create and edit modals. This caused a html error in the browser with conflicting duplicated element ids. This secondary problem was solved by setting no-id to true.  This change does not effect validation.