### PR TITLE
Sprint2 b 03812 plaintext viewer

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -176,6 +176,10 @@
   <script src="config/runTime.js"></script>
   <script src="config/routes.js"></script>
 
+
+  <!-- Components -->
+  <script src="components/plaintextLoader.js"></script>
+
   <!-- Directives -->
   <script src="directives/adminTabsDirective.js"></script>
   <script src="directives/repositoryViewVerificationDirective.js"></script>

--- a/src/main/webapp/app/components/plaintextLoader.js
+++ b/src/main/webapp/app/components/plaintextLoader.js
@@ -1,0 +1,15 @@
+cap.component('plaintextLoader', {
+  template: '<pre class="plaintext-loader">{{content | json}}</pre>',
+  bindings: {
+    src: '<'
+  },
+  controller: function($scope, $http) {
+    
+    this.$onInit = function() {
+      $http.get(this.src).then(function(res) {
+        $scope.content = res.data;
+      });
+    }; 
+
+  }
+});

--- a/src/main/webapp/app/config/appConfig.js
+++ b/src/main/webapp/app/config/appConfig.js
@@ -33,7 +33,7 @@ var appConfig = {
 
     'mockRole': 'admin',
 
-    'contentMap': {"image": ["image/jpeg","image/png","image/gif"],"seadragon": ["image/jp2","image/tiff"]},
+    'contentMap': {"image": ["image/jpeg","image/png","image/gif"],"seadragon": ["image/jp2","image/tiff"], "plaintext": ["text/plain", "text/html", "text/javascript", "text/css", "application/json"]},
 
     'cantaloupeBaseUrl': 'https://api-dev.library.tamu.edu/iiif/2/',
     'fedoraPath': '/fcrepo/rest/',

--- a/src/main/webapp/app/config/routes.js
+++ b/src/main/webapp/app/config/routes.js
@@ -1,4 +1,4 @@
-cap.config(function ($locationProvider, $routeProvider, $sceDelegateProvider, appConfig) {
+cap.config(function ($locationProvider, $routeProvider, appConfig) {
 
       $locationProvider.html5Mode(true);
 
@@ -41,12 +41,5 @@ cap.config(function ($locationProvider, $routeProvider, $sceDelegateProvider, ap
       otherwise({
           redirectTo: '/error/404'
       });
-
-      $sceDelegateProvider.resourceUrlWhitelist([
-        // Allow same origin resource loads.
-        'self',
-        // Allow loading from our assets domain.  Notice the difference between * and **.
-        'https://*.library.tamu.edu/**'
-      ]);
 
   });

--- a/src/main/webapp/app/config/routes.js
+++ b/src/main/webapp/app/config/routes.js
@@ -1,4 +1,4 @@
-cap.config(function ($locationProvider, $routeProvider, appConfig) {
+cap.config(function ($locationProvider, $routeProvider) {
 
       $locationProvider.html5Mode(true);
 

--- a/src/main/webapp/app/config/routes.js
+++ b/src/main/webapp/app/config/routes.js
@@ -1,4 +1,4 @@
-cap.config(function ($locationProvider, $routeProvider) {
+cap.config(function ($locationProvider, $routeProvider, $sceDelegateProvider, appConfig) {
 
       $locationProvider.html5Mode(true);
 
@@ -41,5 +41,12 @@ cap.config(function ($locationProvider, $routeProvider) {
       otherwise({
           redirectTo: '/error/404'
       });
+
+      $sceDelegateProvider.resourceUrlWhitelist([
+        // Allow same origin resource loads.
+        'self',
+        // Allow loading from our assets domain.  Notice the difference between * and **.
+        'https://*.library.tamu.edu/**'
+      ]);
 
   });

--- a/src/main/webapp/app/config/runTime.js
+++ b/src/main/webapp/app/config/runTime.js
@@ -17,5 +17,4 @@ cap.run(function($route, $rootScope, $location) {
         }
         return original.apply($location, [path]);
     };
-
 });

--- a/src/main/webapp/app/resources/styles/sass/app.scss
+++ b/src/main/webapp/app/resources/styles/sass/app.scss
@@ -8,6 +8,7 @@
 @import "splash/all";
 @import "repositoryViewManagement/all";
 @import "repositoryViewContext/all";
+@import "components/all";
 @import "directives/all";
 @import "modals/all";
 

--- a/src/main/webapp/app/resources/styles/sass/components/_all.scss
+++ b/src/main/webapp/app/resources/styles/sass/components/_all.scss
@@ -1,0 +1,1 @@
+@import "./plaintextLoader"

--- a/src/main/webapp/app/resources/styles/sass/components/_plaintextLoader.scss
+++ b/src/main/webapp/app/resources/styles/sass/components/_plaintextLoader.scss
@@ -1,0 +1,7 @@
+pre.plaintext-loader {
+  white-space: pre-wrap;       /* css-3 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word; 
+}

--- a/src/main/webapp/app/views/directives/viewers/plaintextViewer.html
+++ b/src/main/webapp/app/views/directives/viewers/plaintextViewer.html
@@ -1,0 +1,1 @@
+<plaintext-loader src="resource"></plaintext-loader>


### PR DESCRIPTION
Resolves B-03812: As a curator, I would like a plaintext viewer template to view plaintext files.

This adds a new component, the plaintext-loader, which is used by the plaintextViewer template to load plaintext directly from the targeted repository. This assumes that the targeted repository will honor the get request by returning the data at res.data. 

This uses pre tags, with modified styling to ensure word wrapping, and angular's built-in json filter for formatting. 