### PR TITLE
As a curator, I would like dc:title and rdf:label metadata displayed prominently at the top of the resource page

### DIFF
--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -617,20 +617,19 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
             repositoryViewContext.setName(contextUri);
         }
 
-        if (repositoryViewContext.isResource()) {
-            Optional<String> fileName = getLiteralForProperty(model, model.createProperty(EBU_FILENAME_PREDICATE));
-            if (fileName.isPresent()) {
-                repositoryViewContext.setName(fileName.get());
-            }
-        } else {
-            Optional<String> title = getLiteralForProperty(model, RDFS.label);
-            if (!title.isPresent()) {
-                title = getLiteralForProperty(model, DC.title);
-            }
+        Optional<String> title = getLiteralForProperty(model, RDFS.label);
+        if (!title.isPresent()) {
+            title = getLiteralForProperty(model, DC.title);
 
-            if (title.isPresent()) {
-                repositoryViewContext.setName(title.get());
+            if (!title.isPresent()) {
+                if (repositoryViewContext.isResource()) {
+                    title = getLiteralForProperty(model, model.createProperty(EBU_FILENAME_PREDICATE));
+                }
             }
+        }
+
+        if (title.isPresent()) {
+            repositoryViewContext.setName(title.get());
         }
 
         if (repositoryViewContext.getIsVersion()) {


### PR DESCRIPTION
If both the dc:title and the rdf:label are not defined, it will still fallback to the filename.

Discovery order:
1. rdf:label
2. dc:title
3. filename (resources only)