### PR TITLE
As a curator, I would like to collapsing properties individually

### DIFF
--- a/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
+++ b/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import edu.tamu.cap.model.repositoryviewcontext.TransactionDetails;
@@ -20,9 +21,9 @@ public class RepositoryViewContext implements Serializable {
 
     private Triple parent;
 
-    private List<Triple> properties;
+    private Map<String, List<Triple>> properties;
 
-    private List<Triple> metadata;
+    private Map<String, List<Triple>> metadata;
 
     private List<RepositoryViewContext> children;
 
@@ -36,8 +37,8 @@ public class RepositoryViewContext implements Serializable {
 
 	public RepositoryViewContext() {
         super();
-        properties = new ArrayList<Triple>();
-        metadata = new ArrayList<Triple>();
+        properties = new HashMap<String, List<Triple>>();
+        metadata = new HashMap<String, List<Triple>>();
         versions = new ArrayList<Version>();
         children = new ArrayList<RepositoryViewContext>();
         features = new HashMap<String, Boolean>();
@@ -80,28 +81,68 @@ public class RepositoryViewContext implements Serializable {
         return triple != null ? triple.getObject().equals(FedoraService.FEDORA_BINRAY_PREDICATE) : false;
     }
 
-    public List<Triple> getProperties() {
+    public Map<String, List<Triple>> getProperties() {
         return properties;
     }
 
-    public void setProperties(List<Triple> properties) {
+    public List<Triple> getPropertiesAll() {
+        List<Triple> triples = new ArrayList<Triple>();
+
+        for(Entry<String, List<Triple>> set: properties.entrySet()){
+            List<Triple> values = set.getValue();
+            for (int i = 0; i < values.size(); i++) {
+                triples.add(values.get(i));
+            }
+        }
+
+        return triples;
+    }
+
+    public void setProperties(Map<String, List<Triple>> properties) {
         this.properties = properties;
     }
 
     public void addProperty(Triple property) {
-        properties.add(property);
+        String key = property.getPredicate();
+        if (properties.containsKey(key)) {
+            properties.get(key).add(property);
+        } else {
+            List<Triple> list = new ArrayList<Triple>();
+            list.add(property);
+            properties.put(key, list);
+        }
     }
 
-    public List<Triple> getMetadata() {
+    public Map<String, List<Triple>> getMetadata() {
         return metadata;
     }
 
-    public void setMetadata(List<Triple> metadata) {
+    public List<Triple> getMetadataAll() {
+        List<Triple> triples = new ArrayList<Triple>();
+
+        for(Entry<String, List<Triple>> set: metadata.entrySet()){
+            List<Triple> values = set.getValue();
+            for (int i = 0; i < values.size(); i++) {
+                triples.add(values.get(i));
+            }
+        }
+
+        return triples;
+    }
+
+    public void setMetadata(Map<String, List<Triple>> metadata) {
         this.metadata = metadata;
     }
 
     public void addMetadum(Triple metadatum) {
-        metadata.add(metadatum);
+        String key = metadatum.getPredicate();
+        if (metadata.containsKey(key)) {
+            metadata.get(key).add(metadatum);
+        } else {
+            List<Triple> list = new ArrayList<Triple>();
+            list.add(metadatum);
+            metadata.put(key, list);
+        }
     }
 
     public List<RepositoryViewContext> getChildren() {

--- a/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
+++ b/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
@@ -134,7 +134,7 @@ public class RepositoryViewContext implements Serializable {
         this.metadata = metadata;
     }
 
-    public void addMetadum(Triple metadatum) {
+    public void addMetadatum(Triple metadatum) {
         String key = metadatum.getPredicate();
         if (metadata.containsKey(key)) {
             metadata.get(key).add(metadatum);

--- a/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
+++ b/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
@@ -21,9 +21,9 @@ public class RepositoryViewContext implements Serializable {
 
     private Triple parent;
 
-    private Map<String, List<Triple>> properties;
+    private List<Triple> properties;
 
-    private Map<String, List<Triple>> metadata;
+    private List<Triple> metadata;
 
     private List<RepositoryViewContext> children;
 
@@ -37,8 +37,8 @@ public class RepositoryViewContext implements Serializable {
 
 	public RepositoryViewContext() {
         super();
-        properties = new HashMap<String, List<Triple>>();
-        metadata = new HashMap<String, List<Triple>>();
+        properties = new ArrayList<Triple>();
+        metadata = new ArrayList<Triple>();
         versions = new ArrayList<Version>();
         children = new ArrayList<RepositoryViewContext>();
         features = new HashMap<String, Boolean>();
@@ -81,68 +81,28 @@ public class RepositoryViewContext implements Serializable {
         return triple != null ? triple.getObject().equals(FedoraService.FEDORA_BINRAY_PREDICATE) : false;
     }
 
-    public Map<String, List<Triple>> getProperties() {
+    public List<Triple> getProperties() {
         return properties;
     }
 
-    public List<Triple> getPropertiesList() {
-        List<Triple> triples = new ArrayList<Triple>();
-
-        for(Entry<String, List<Triple>> set: properties.entrySet()){
-            List<Triple> values = set.getValue();
-            for (int i = 0; i < values.size(); i++) {
-                triples.add(values.get(i));
-            }
-        }
-
-        return triples;
-    }
-
-    public void setProperties(Map<String, List<Triple>> properties) {
+    public void setProperties(List<Triple> properties) {
         this.properties = properties;
     }
 
     public void addProperty(Triple property) {
-        String key = property.getPredicate();
-        if (properties.containsKey(key)) {
-            properties.get(key).add(property);
-        } else {
-            List<Triple> list = new ArrayList<Triple>();
-            list.add(property);
-            properties.put(key, list);
-        }
+        properties.add(property);
     }
 
-    public Map<String, List<Triple>> getMetadata() {
+    public List<Triple> getMetadata() {
         return metadata;
     }
 
-    public List<Triple> getMetadataList() {
-        List<Triple> triples = new ArrayList<Triple>();
-
-        for(Entry<String, List<Triple>> set: metadata.entrySet()){
-            List<Triple> values = set.getValue();
-            for (int i = 0; i < values.size(); i++) {
-                triples.add(values.get(i));
-            }
-        }
-
-        return triples;
-    }
-
-    public void setMetadata(Map<String, List<Triple>> metadata) {
+    public void setMetadata(List<Triple> metadata) {
         this.metadata = metadata;
     }
 
     public void addMetadatum(Triple metadatum) {
-        String key = metadatum.getPredicate();
-        if (metadata.containsKey(key)) {
-            metadata.get(key).add(metadatum);
-        } else {
-            List<Triple> list = new ArrayList<Triple>();
-            list.add(metadatum);
-            metadata.put(key, list);
-        }
+        metadata.add(metadatum);
     }
 
     public List<RepositoryViewContext> getChildren() {

--- a/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
+++ b/src/main/java/edu/tamu/cap/model/response/RepositoryViewContext.java
@@ -85,7 +85,7 @@ public class RepositoryViewContext implements Serializable {
         return properties;
     }
 
-    public List<Triple> getPropertiesAll() {
+    public List<Triple> getPropertiesList() {
         List<Triple> triples = new ArrayList<Triple>();
 
         for(Entry<String, List<Triple>> set: properties.entrySet()){
@@ -117,7 +117,7 @@ public class RepositoryViewContext implements Serializable {
         return metadata;
     }
 
-    public List<Triple> getMetadataAll() {
+    public List<Triple> getMetadataList() {
         List<Triple> triples = new ArrayList<Triple>();
 
         for(Entry<String, List<Triple>> set: metadata.entrySet()){

--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -213,8 +213,8 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
 
         List<Triple> allTriples = new ArrayList<Triple>();
 
-        allTriples.addAll(context.getProperties());
-        allTriples.addAll(context.getMetadata());
+        allTriples.addAll(context.getPropertiesAll());
+        allTriples.addAll(context.getMetadataAll());
         //TODO add all resource triples
 
         return allTriples;
@@ -270,7 +270,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
     @Override
     public List<Triple> getMetadata(String contextUri) throws Exception {
         RepositoryViewContext context = getRepositoryViewContext(contextUri);
-        return context.getMetadata();
+        return context.getMetadataAll();
     }
 
     @Override
@@ -351,7 +351,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
         model.read(response.getBody(), null, "text/turtle");
         model.createResource("").addProperty(DC.title, "Fixity Report");
 
-        FixityReport fixityReportContext = FixityReport.of(buildRepositoryViewContext(model, contextUri).getProperties());
+        FixityReport fixityReportContext = FixityReport.of(buildRepositoryViewContext(model, contextUri).getPropertiesAll());
 
         return fixityReportContext;
     }
@@ -676,6 +676,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
         return model;
     }
 
+    @Override
     public RepositoryView getRepositoryView() {
         return repositoryView;
     }

--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -577,7 +577,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
 
                     for (String prefix : repositoryView.getMetadataPrefixes()) {
                         if (predicate.startsWith(prefix)) {
-                            repositoryViewContext.addMetadum(triple);
+                            repositoryViewContext.addMetadatum(triple);
                         }
                     }
                 }

--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -213,8 +213,8 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
 
         List<Triple> allTriples = new ArrayList<Triple>();
 
-        allTriples.addAll(context.getPropertiesList());
-        allTriples.addAll(context.getMetadataList());
+        allTriples.addAll(context.getProperties());
+        allTriples.addAll(context.getMetadata());
         //TODO add all resource triples
 
         return allTriples;
@@ -270,7 +270,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
     @Override
     public List<Triple> getMetadata(String contextUri) throws Exception {
         RepositoryViewContext context = getRepositoryViewContext(contextUri);
-        return context.getMetadataList();
+        return context.getMetadata();
     }
 
     @Override
@@ -351,7 +351,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
         model.read(response.getBody(), null, "text/turtle");
         model.createResource("").addProperty(DC.title, "Fixity Report");
 
-        FixityReport fixityReportContext = FixityReport.of(buildRepositoryViewContext(model, contextUri).getPropertiesList());
+        FixityReport fixityReportContext = FixityReport.of(buildRepositoryViewContext(model, contextUri).getProperties());
 
         return fixityReportContext;
     }

--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -213,8 +213,8 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
 
         List<Triple> allTriples = new ArrayList<Triple>();
 
-        allTriples.addAll(context.getPropertiesAll());
-        allTriples.addAll(context.getMetadataAll());
+        allTriples.addAll(context.getPropertiesList());
+        allTriples.addAll(context.getMetadataList());
         //TODO add all resource triples
 
         return allTriples;
@@ -270,7 +270,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
     @Override
     public List<Triple> getMetadata(String contextUri) throws Exception {
         RepositoryViewContext context = getRepositoryViewContext(contextUri);
-        return context.getMetadataAll();
+        return context.getMetadataList();
     }
 
     @Override
@@ -351,7 +351,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
         model.read(response.getBody(), null, "text/turtle");
         model.createResource("").addProperty(DC.title, "Fixity Report");
 
-        FixityReport fixityReportContext = FixityReport.of(buildRepositoryViewContext(model, contextUri).getPropertiesAll());
+        FixityReport fixityReportContext = FixityReport.of(buildRepositoryViewContext(model, contextUri).getPropertiesList());
 
         return fixityReportContext;
     }

--- a/src/main/webapp/app/controllers/repositoryViewContextController.js
+++ b/src/main/webapp/app/controllers/repositoryViewContextController.js
@@ -240,7 +240,7 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
       for (var i in $scope.context.properties) {
         var properties = $scope.context.properties[i];
         for (var j in properties) {
-          var triple = properties[i];
+          var triple = properties[j];
           if (triple.predicate.indexOf("#hasMimeType") !== -1) {
             contentType = $filter("removeQuotes")(triple.object);
             break;

--- a/src/main/webapp/app/controllers/repositoryViewContextController.js
+++ b/src/main/webapp/app/controllers/repositoryViewContextController.js
@@ -6,6 +6,10 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
 
   $scope.repositoryViewForm = {};
 
+  $scope.triplePropertiesCollapsed = {};
+
+  $scope.tripleMetadataCollapsed = {};
+
   $scope.submitClicked = false;
 
   $scope.theaterMode = false;

--- a/src/main/webapp/app/controllers/repositoryViewContextController.js
+++ b/src/main/webapp/app/controllers/repositoryViewContextController.js
@@ -234,18 +234,21 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
       var typeMap = {"jpg":"image/jpeg","png":"image/png","pdf":"application/pdf"};
 
       for (var i in $scope.context.properties) {
-        var triple = $scope.context.properties[i];
-        if (triple.predicate.indexOf("#hasMimeType") !== -1) {
-          contentType = $filter("removeQuotes")(triple.object);
-          break;
-        }
+        var properties = $scope.context.properties[i];
+        for (var j in properties) {
+          var triple = properties[i];
+          if (triple.predicate.indexOf("#hasMimeType") !== -1) {
+            contentType = $filter("removeQuotes")(triple.object);
+            break;
+          }
 
-        if (triple.predicate.indexOf("#filename") !== -1) {
-          var temp = triple.object.split(".");
-          temp = temp[temp.length-1];
-          backupContentType = temp.substring(0,temp.length-1);
-          if (typeMap[backupContentType] !== undefined) {
-            backupContentType = typeMap[backupContentType];
+          if (triple.predicate.indexOf("#filename") !== -1) {
+            var temp = triple.object.split(".");
+            temp = temp[temp.length-1];
+            backupContentType = temp.substring(0,temp.length-1);
+            if (typeMap[backupContentType] !== undefined) {
+              backupContentType = typeMap[backupContentType];
+            }
           }
         }
       }
@@ -283,22 +286,26 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
           var hasFile = false;
           var isPCDM = false;
           for (var i in contextProperties) {
-            var triple = contextProperties[i];
-            if (!hasFile) {
-              if (triple.predicate.indexOf("#hasFile") !== -1) {
-                hasFile = true;
+            var properties = contextProperties[i];
+
+            for (var j in properties) {
+              var triple = properties[j];
+              if (!hasFile) {
+                if (triple.predicate.indexOf("#hasFile") !== -1) {
+                  hasFile = true;
+                }
               }
-            }
-            if (!isPCDM) {
-              if (triple.predicate.indexOf("#type") !== -1) {
-                  if (triple.object === "http://pcdm.org/models#Object") {
-                    isPCDM = true;
-                  }
+              if (!isPCDM) {
+                if (triple.predicate.indexOf("#type") !== -1) {
+                    if (triple.object === "http://pcdm.org/models#Object") {
+                      isPCDM = true;
+                    }
+                }
               }
-            }
-            if (isPCDM && hasFile) {
-              hasManifest = true;
-              break;
+              if (isPCDM && hasFile) {
+                hasManifest = true;
+                break;
+              }
             }
           }
           if (hasManifest) {

--- a/src/main/webapp/app/controllers/repositoryViewContextController.js
+++ b/src/main/webapp/app/controllers/repositoryViewContextController.js
@@ -18,6 +18,19 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
     $scope.theaterMode = mode ? mode : !$scope.theaterMode;
   };
 
+  $scope.mapTriplesByPredicate = function(triples) {
+    var map = {};
+    angular.forEach(triples, function (triple) {
+        if (!map.hasOwnProperty(triple.predicate)) {
+          map[triple.predicate] = [];
+        }
+
+        map[triple.predicate].push(triple);
+    });
+
+    return map;
+  };
+
   RepositoryViewRepo.ready().then(function () {
 
     $scope.repositoryView = RepositoryViewRepo.findByName(decodeURI($routeParams.irName));
@@ -238,21 +251,18 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
       var typeMap = {"jpg":"image/jpeg","png":"image/png","pdf":"application/pdf"};
 
       for (var i in $scope.context.properties) {
-        var properties = $scope.context.properties[i];
-        for (var j in properties) {
-          var triple = properties[j];
-          if (triple.predicate.indexOf("#hasMimeType") !== -1) {
-            contentType = $filter("removeQuotes")(triple.object);
-            break;
-          }
+        var triple = $scope.context.properties[i];
+        if (triple.predicate.indexOf("#hasMimeType") !== -1) {
+          contentType = $filter("removeQuotes")(triple.object);
+          break;
+        }
 
-          if (triple.predicate.indexOf("#filename") !== -1) {
-            var temp = triple.object.split(".");
-            temp = temp[temp.length-1];
-            backupContentType = temp.substring(0,temp.length-1);
-            if (typeMap[backupContentType] !== undefined) {
-              backupContentType = typeMap[backupContentType];
-            }
+        if (triple.predicate.indexOf("#filename") !== -1) {
+          var temp = triple.object.split(".");
+          temp = temp[temp.length-1];
+          backupContentType = temp.substring(0,temp.length-1);
+          if (typeMap[backupContentType] !== undefined) {
+            backupContentType = typeMap[backupContentType];
           }
         }
       }
@@ -290,26 +300,22 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
           var hasFile = false;
           var isPCDM = false;
           for (var i in contextProperties) {
-            var properties = contextProperties[i];
-
-            for (var j in properties) {
-              var triple = properties[j];
-              if (!hasFile) {
-                if (triple.predicate.indexOf("#hasFile") !== -1) {
-                  hasFile = true;
-                }
+            var triple = contextProperties[i];
+            if (!hasFile) {
+              if (triple.predicate.indexOf("#hasFile") !== -1) {
+                hasFile = true;
               }
-              if (!isPCDM) {
-                if (triple.predicate.indexOf("#type") !== -1) {
-                    if (triple.object === "http://pcdm.org/models#Object") {
-                      isPCDM = true;
-                    }
-                }
+            }
+            if (!isPCDM) {
+              if (triple.predicate.indexOf("#type") !== -1) {
+                  if (triple.object === "http://pcdm.org/models#Object") {
+                    isPCDM = true;
+                  }
               }
-              if (isPCDM && hasFile) {
-                hasManifest = true;
-                break;
-              }
+            }
+            if (isPCDM && hasFile) {
+              hasManifest = true;
+              break;
             }
           }
           if (hasManifest) {

--- a/src/main/webapp/app/directives/repositoryViewSectionDirective.js
+++ b/src/main/webapp/app/directives/repositoryViewSectionDirective.js
@@ -14,7 +14,7 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
           editAction: "&"
         },
         link: function($scope, elem, attr, ctrl, transclude) {
-          
+
           angular.extend(this, $controller('CoreAdminController', {
               $scope: $scope
           }));
@@ -24,7 +24,7 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
           transclude($scope, function(clone, $scope) {
             elem.find('.transclude').replaceWith(clone);
           });
-            
+
           $scope.selectedListElements = [];
 
           $scope.manuallyCollapse = function() {
@@ -32,7 +32,7 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
             RepositoryViewSectionService.setManuallyCollapsed($scope.title, true);
           };
 
-          $scope.manuallyExpande = function() {
+          $scope.manuallyExpand = function() {
             $scope.contentExpanded = true;
             RepositoryViewSectionService.setManuallyCollapsed($scope.title, false);
           };
@@ -44,7 +44,7 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
           $scope.confirmDelete = function() {
             $scope.removeAction({"items": $scope.selectedListElements}).then(function() {
               $scope.removeListElements=false;
-              $scope.selectedListElements.length=0;          
+              $scope.selectedListElements.length=0;
             });
           };
 

--- a/src/main/webapp/app/model/repositoryViewContext.js
+++ b/src/main/webapp/app/model/repositoryViewContext.js
@@ -49,7 +49,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
         });
       });
       return reloadPromise;
-    }; 
+    };
 
     repositoryViewContext.getChildContext = function (triple) {
       if (!children[triple.object]) {
@@ -163,7 +163,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
 
       var formData = new FormData();
       formData.append("file", file, file.name);
-      
+
       var createPromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().resource, {
         method: HttpMethodVerbs.POST,
         headers: {
@@ -237,7 +237,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
     };
 
     repositoryViewContext.updateMetadatum = function (metadataTriple, newValue) {
-      
+
       var updatePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().metadata, {
         method: HttpMethodVerbs.PUT,
         query: {
@@ -246,7 +246,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
         },
         data: metadataTriple
       });
-      
+
       return updatePromise;
 
     };
@@ -318,14 +318,14 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
     repositoryViewContext.getQueryHelp = function () {
 
       if(!queryHelp.message) {
-        
+
         var updatePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().advancedQuery, {
           method: HttpMethodVerbs.GET,
           query: {
             contextUri: repositoryViewContext.uri
           }
         });
-  
+
         updatePromise.then(function (res) {
           queryHelp.query = angular.fromJson(res.body).payload.String;
         });

--- a/src/main/webapp/app/resources/styles/sass/repositoryViewContext/_all.scss
+++ b/src/main/webapp/app/resources/styles/sass/repositoryViewContext/_all.scss
@@ -9,6 +9,10 @@
         @import "./propertiesSection";
     }
 
+    .metadata-section {
+        @import "./metadataSection";
+    }
+
     .preview {
         @import "./preview";
     }

--- a/src/main/webapp/app/resources/styles/sass/repositoryViewContext/_metadataSection.scss
+++ b/src/main/webapp/app/resources/styles/sass/repositoryViewContext/_metadataSection.scss
@@ -1,0 +1,18 @@
+.ir-section {
+  .context-metadata {
+    .metadata-term {
+      display: inline;
+      padding-right: 5px;
+    }
+
+    .metadata-collapsable {
+      line-height: 1.42857;
+    }
+
+    @media (min-width: 768px) {
+      .metadata-collapsable  {
+        float: left;
+      }
+    }
+  }
+}

--- a/src/main/webapp/app/resources/styles/sass/repositoryViewContext/_propertiesSection.scss
+++ b/src/main/webapp/app/resources/styles/sass/repositoryViewContext/_propertiesSection.scss
@@ -7,6 +7,22 @@
   word-wrap: break-word;
   hyphens: auto;
 
+  .context-property {
+    .property-term {
+      display: inline;
+      padding-right: 5px;
+    }
+
+    .property-collapsable {
+      line-height: 1.42857;
+    }
+
+    @media (min-width: 768px) {
+      .property-collapsable  {
+        float: left;
+      }
+    }
+  }
 }
 
 .preview {

--- a/src/main/webapp/app/views/directives/repositoryViewSection.html
+++ b/src/main/webapp/app/views/directives/repositoryViewSection.html
@@ -17,7 +17,7 @@
         <span class="glyphicon glyphicon-remove"></span>
       </button>
     </div>
-    <button class="btn btn-default btn-xs pull-right" ng-click="manuallyExpande()" ng-hide="contentExpanded||!getListLength()">Expand</button>
+    <button class="btn btn-default btn-xs pull-right" ng-click="manuallyExpand()" ng-hide="contentExpanded||!getListLength()">Expand</button>
     <h3 class="panel-title">{{title}} <span class="badge">{{getListLength() || 0}}</span></h3>
   </div>
 

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -122,10 +122,10 @@
             <span class="glyphicon glyphicon-minus clickable" ng-click="propertiesCollapsed=true" ng-show="(!context.resource||theaterMode)&&!propertiesCollapsed"></span>
           </h4>
           <div ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)">
-            <dl class="dl-horizontal" ng-repeat="triple in context.properties | unique:'predicate'">
-              <dt><a href="{{triple.predicate}}">{{triple.predicate | metadataLabel }}</a></dt>
-              <dd ng-repeat="t in context.properties | filter:{predicate:triple.predicate}:true">
-                  {{t.object | propertyValue}}
+            <dl class="dl-horizontal" ng-repeat="(predicate, property) in context.properties">
+              <dt><a href="{{predicate}}">{{predicate | metadataLabel}}</a></dt>
+              <dd ng-repeat="triple in property">
+                  {{triple.object | propertyValue}}
               </dd>
             </dl>
           </div>
@@ -146,23 +146,23 @@
         edit-action="updateMetadatum(triple,newObject)"
         remove-action="context.removeMetadata(items)">
         <br ng-show="contentExpanded">
-        <dl ng-show="contentExpanded" class="dl-horizontal" ng-repeat="triple in list | unique:'predicate'">
+        <dl ng-show="contentExpanded" class="dl-horizontal" ng-repeat="(predicate, metadata) in list">
           <dt>
               <input ng-show="removeListElements&&filteredList.length>1" type="checkbox" ng-checked="checkAll" ng-click="checkAll=!checkAll;checkAll?selectAll(filteredList):selectedListElements.length=0">
-              <a href="{{triple.predicate}}">{{triple.predicate | metadataLabel }}</a>
+              <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
           </dt>
-          <dd ng-mouseenter="showEditBtn=true" ng-mouseleave="showEditBtn=false" ng-repeat="t in filteredList = (list |filter:{predicate:triple.predicate}:true)">
-            <input ng-show="removeListElements" type="checkbox" ng-checked="selectedListElements.indexOf(t)!==-1" ng-click="selectedListElements.indexOf(t)===-1?selectedListElements.push(t):selectedListElements.splice(selectedListElements.indexOf(t),1)">
-            <span ng-show="!editValue&&selectedListElements.indexOf(t)===-1">
-              {{t.object | removeQuotes}}
-              <span ng-show="showEditBtn&&!context.isVersion" class="glyphicon glyphicon-pencil clickable" ng-click="editValue=t.object"></span>
+          <dd ng-mouseenter="showEditBtn=true" ng-mouseleave="showEditBtn=false" ng-repeat="triple in metadata">
+            <input ng-show="removeListElements" type="checkbox" ng-checked="selectedListElements.indexOf(triple)!==-1" ng-click="selectedListElements.indexOf(triple)===-1?selectedListElements.push(triple):selectedListElements.splice(selectedListElements.indexOf(triple),1)">
+            <span ng-show="!editValue&&selectedListElements.indexOf(triple)===-1">
+              {{triple.object | removeQuotes}}
+              <span ng-show="showEditBtn&&!context.isVersion" class="glyphicon glyphicon-pencil clickable" ng-click="editValue=triple.object"></span>
             </span>
             <div ng-show="editValue" class="row">
               <div class="col-md-6">
                   <div class="input-group">
                     <input type="text" class="form-control" ng-model="editValue" remove-quotes>
                     <div class="input-group-btn">
-                      <button ng-show="!editWorking" class="btn btn-default" ng-click="editItem({triple:t,newObject:editValue});editValue=null;" ng-disabled="t.object===editValue">
+                      <button ng-show="!editWorking" class="btn btn-default" ng-click="editItem({triple, newObject:editValue});editValue=null;" ng-disabled="triple.object===editValue">
                         <span class="glyphicon glyphicon-ok"></span>
                       </button>
                       <button ng-show="!editWorking" class="btn btn-default" ng-click="editValue=null">
@@ -175,7 +175,7 @@
                   </div>
                 </div>
             </div>
-            <del ng-if="removeListElements && selectedListElements.indexOf(t)!==-1">{{t.object | removeQuotes}}</del>
+            <del ng-if="removeListElements && selectedListElements.indexOf(triple)!==-1">{{triple.object | removeQuotes}}</del>
           </dd>
         </dl>
       </repository-viewsection>

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -125,7 +125,9 @@
             <dl class="dl-horizontal" ng-repeat="(predicate, property) in context.properties">
               <dt><a href="{{predicate}}">{{predicate | metadataLabel}}</a></dt>
               <dd ng-repeat="triple in property">
-                  {{triple.object | propertyValue}}
+                <span ng-show="!triplePropertiesCollapsed[predicate]" >{{triple.object | propertyValue}}</span>
+                <span title="expand {{predicate | metadataLabel}}" ng-if="$first && property.length > 1" class="glyphicon glyphicon-plus clickable" ng-click="triplePropertiesCollapsed[predicate]=false" ng-show="triplePropertiesCollapsed[predicate]"></span>
+                <span title="collapse {{predicate | metadataLabel}}" ng-if="$first && property.length > 1" class="glyphicon glyphicon-minus clickable" ng-click="triplePropertiesCollapsed[predicate]=true" ng-show="!triplePropertiesCollapsed[predicate]"></span>
               </dd>
             </dl>
           </div>
@@ -154,10 +156,12 @@
           <dd ng-mouseenter="showEditBtn=true" ng-mouseleave="showEditBtn=false" ng-repeat="triple in metadata">
             <input ng-show="removeListElements" type="checkbox" ng-checked="selectedListElements.indexOf(triple)!==-1" ng-click="selectedListElements.indexOf(triple)===-1?selectedListElements.push(triple):selectedListElements.splice(selectedListElements.indexOf(triple),1)">
             <span ng-show="!editValue&&selectedListElements.indexOf(triple)===-1">
-              {{triple.object | removeQuotes}}
-              <span ng-show="showEditBtn&&!context.isVersion" class="glyphicon glyphicon-pencil clickable" ng-click="editValue=triple.object"></span>
+              <span ng-show="!context.tripleMetadataCollapsed[predicate]">{{triple.object | removeQuotes}}</span>
+              <span title="collapse {{predicate | metadataLabel}}" ng-if="$first && metadata.length > 1" class="glyphicon glyphicon-minus clickable" ng-click="context.tripleMetadataCollapsed[predicate]=true" ng-show="!context.tripleMetadataCollapsed[predicate]"></span>
+              <span title="expand {{predicate | metadataLabel}}" ng-if="$first && metadata.length > 1" class="glyphicon glyphicon-plus clickable" ng-click="context.tripleMetadataCollapsed[predicate]=false" ng-show="context.tripleMetadataCollapsed[predicate]"></span>
+              <span class="glyphicon glyphicon-pencil clickable" ng-click="editValue=triple.object" ng-show="showEditBtn && !context.isVersion && !context.tripleMetadataCollapsed[predicate]" ></span>
             </span>
-            <div ng-show="editValue" class="row">
+            <div ng-show="editValue && !context.tripleMetadataCollapsed[predicate]" class="row">
               <div class="col-md-6">
                   <div class="input-group">
                     <input type="text" class="form-control" ng-model="editValue" remove-quotes>

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -121,13 +121,15 @@
             <span class="glyphicon glyphicon-plus clickable" ng-click="propertiesCollapsed=false" ng-show="(!context.resource||theaterMode)&&propertiesCollapsed"></span>
             <span class="glyphicon glyphicon-minus clickable" ng-click="propertiesCollapsed=true" ng-show="(!context.resource||theaterMode)&&!propertiesCollapsed"></span>
           </h4>
-          <div ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)">
+          <div class="context-property" ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)">
             <dl class="dl-horizontal" ng-repeat="(predicate, property) in context.properties">
-              <dt><a href="{{predicate}}">{{predicate | metadataLabel}}</a></dt>
+              <dt class="property-term">
+                <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
+              </dt>
+              <span title="expand {{predicate | metadataLabel}}" class="glyphicon glyphicon-plus clickable property-collapsable" ng-if="property.length > 1" ng-click="triplePropertiesCollapsed[predicate]=false" ng-show="triplePropertiesCollapsed[predicate]"></span>
+              <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-plus clickable property-collapsable" ng-if="property.length > 1" ng-click="triplePropertiesCollapsed[predicate]=true" ng-show="!triplePropertiesCollapsed[predicate]"></span>
               <dd ng-repeat="triple in property">
                 <span ng-show="!triplePropertiesCollapsed[predicate]" >{{triple.object | propertyValue}}</span>
-                <span title="expand {{predicate | metadataLabel}}" ng-if="$first && property.length > 1" class="glyphicon glyphicon-plus clickable" ng-click="triplePropertiesCollapsed[predicate]=false" ng-show="triplePropertiesCollapsed[predicate]"></span>
-                <span title="collapse {{predicate | metadataLabel}}" ng-if="$first && property.length > 1" class="glyphicon glyphicon-minus clickable" ng-click="triplePropertiesCollapsed[predicate]=true" ng-show="!triplePropertiesCollapsed[predicate]"></span>
               </dd>
             </dl>
           </div>
@@ -137,7 +139,7 @@
 
     </div>
 
-    <div class="row">
+    <div class="row metadata-section">
       <repository-view-section
         context="context"
         title="'Metadata'"
@@ -148,17 +150,17 @@
         edit-action="updateMetadatum(triple,newObject)"
         remove-action="context.removeMetadata(items)">
         <br ng-show="contentExpanded">
-        <dl ng-show="contentExpanded" class="dl-horizontal" ng-repeat="(predicate, metadata) in list">
-          <dt>
-              <input ng-show="removeListElements&&filteredList.length>1" type="checkbox" ng-checked="checkAll" ng-click="checkAll=!checkAll;checkAll?selectAll(filteredList):selectedListElements.length=0">
-              <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
+        <dl class="dl-horizontal context-metadata" ng-show="contentExpanded" ng-repeat="(predicate, metadata) in list">
+          <dt class="metadata-term">
+            <input ng-show="removeListElements&&filteredList.length>1" type="checkbox" ng-checked="checkAll" ng-click="checkAll=!checkAll;checkAll?selectAll(filteredList):selectedListElements.length=0">
+            <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
           </dt>
+          <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable metadata-collapsable" ng-if="metadata.length > 1" ng-click="context.tripleMetadataCollapsed[predicate]=true" ng-show="!context.tripleMetadataCollapsed[predicate]"></span>
+          <span title="expand {{predicate | metadataLabel}}"  class="glyphicon glyphicon-plus clickable metadata-collapsable" ng-if="metadata.length > 1" ng-click="context.tripleMetadataCollapsed[predicate]=false" ng-show="context.tripleMetadataCollapsed[predicate]"></span>
           <dd ng-mouseenter="showEditBtn=true" ng-mouseleave="showEditBtn=false" ng-repeat="triple in metadata">
             <input ng-show="removeListElements" type="checkbox" ng-checked="selectedListElements.indexOf(triple)!==-1" ng-click="selectedListElements.indexOf(triple)===-1?selectedListElements.push(triple):selectedListElements.splice(selectedListElements.indexOf(triple),1)">
             <span ng-show="!editValue&&selectedListElements.indexOf(triple)===-1">
               <span ng-show="!context.tripleMetadataCollapsed[predicate]">{{triple.object | removeQuotes}}</span>
-              <span title="collapse {{predicate | metadataLabel}}" ng-if="$first && metadata.length > 1" class="glyphicon glyphicon-minus clickable" ng-click="context.tripleMetadataCollapsed[predicate]=true" ng-show="!context.tripleMetadataCollapsed[predicate]"></span>
-              <span title="expand {{predicate | metadataLabel}}" ng-if="$first && metadata.length > 1" class="glyphicon glyphicon-plus clickable" ng-click="context.tripleMetadataCollapsed[predicate]=false" ng-show="context.tripleMetadataCollapsed[predicate]"></span>
               <span class="glyphicon glyphicon-pencil clickable" ng-click="editValue=triple.object" ng-show="showEditBtn && !context.isVersion && !context.tripleMetadataCollapsed[predicate]" ></span>
             </span>
             <div ng-show="editValue && !context.tripleMetadataCollapsed[predicate]" class="row">

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -121,13 +121,13 @@
             <span class="glyphicon glyphicon-plus clickable" ng-click="propertiesCollapsed=false" ng-show="(!context.resource||theaterMode)&&propertiesCollapsed"></span>
             <span class="glyphicon glyphicon-minus clickable" ng-click="propertiesCollapsed=true" ng-show="(!context.resource||theaterMode)&&!propertiesCollapsed"></span>
           </h4>
-          <div class="context-property" ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)">
-            <dl class="dl-horizontal" ng-repeat="(predicate, property) in context.properties">
+          <div class="context-property" ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)" ng-if="context.properties" ng-init="map = mapTriplesByPredicate(context.properties)">
+            <dl class="dl-horizontal" ng-repeat="(predicate, property) in map">
               <dt class="property-term">
                 <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
               </dt>
               <span title="expand {{predicate | metadataLabel}}" class="glyphicon glyphicon-plus clickable property-collapsable" ng-if="property.length > 1" ng-click="triplePropertiesCollapsed[predicate]=false" ng-show="triplePropertiesCollapsed[predicate]"></span>
-              <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-plus clickable property-collapsable" ng-if="property.length > 1" ng-click="triplePropertiesCollapsed[predicate]=true" ng-show="!triplePropertiesCollapsed[predicate]"></span>
+              <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable property-collapsable" ng-if="property.length > 1" ng-click="triplePropertiesCollapsed[predicate]=true" ng-show="!triplePropertiesCollapsed[predicate]"></span>
               <dd ng-repeat="triple in property">
                 <span ng-show="!triplePropertiesCollapsed[predicate]" >{{triple.object | propertyValue}}</span>
               </dd>
@@ -139,12 +139,12 @@
 
     </div>
 
-    <div class="row metadata-section">
+    <div class="row metadata-section" ng-if="context.metadata" ng-init="map = mapTriplesByPredicate(context.metadata)">
       <repository-view-section
         context="context"
         title="'Metadata'"
         type="'metadatum'"
-        list="context.metadata"
+        list="map"
         list-element-action="repositoryView.loadContext(le)"
         add-action="openModal('#addMetadata')"
         edit-action="updateMetadatum(triple,newObject)"

--- a/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
+++ b/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
@@ -113,7 +113,7 @@ public final class FedoraServiceTest {
         context.addMetadatum(mockTriple1);
         context.addMetadatum(mockTriple2);
 
-        List<Triple> metadata = context.getMetadataList();
+        List<Triple> metadata = context.getMetadata();
 
         assertEquals(2, metadata.size(), "Context had incorrect metadata list size!");
     }
@@ -124,7 +124,7 @@ public final class FedoraServiceTest {
 
         context.addProperty(mockTriple1);
 
-        List<Triple> properties = context.getPropertiesList();
+        List<Triple> properties = context.getProperties();
 
         assertEquals(10, properties.size(), "Context had incorrect properties list size!");
     }

--- a/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
+++ b/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
@@ -11,13 +11,16 @@ import java.util.List;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,6 +29,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import edu.tamu.cap.CapApplication;
 import edu.tamu.cap.model.RepositoryView;
 import edu.tamu.cap.model.response.RepositoryViewContext;
+import edu.tamu.cap.model.response.Triple;
 import edu.tamu.cap.model.response.Version;
 
 @ExtendWith(SpringExtension.class)
@@ -40,10 +44,22 @@ public final class FedoraServiceTest {
 
     private final static String TEST_CONTEXT_URI = ROOT_CONTEXT_URI + "/path/to/container";
 
+    private final static Resource TEST_SUBJECT = OWL.Class;
+
+    private final static Property TEST_PREDICATE = RDF.type;
+
+    private final static String TEST_OBJECT_1 = "TestObject1";
+
+    private final static String TEST_OBJECT_2 = "TestObject2";
+
     private HttpServletRequest request;
 
     @InjectMocks
     private FedoraService fedoraService;
+
+    private Triple mockTriple1;
+
+    private Triple mockTriple2;
 
     @BeforeEach
     public void setup() throws IOException {
@@ -66,6 +82,16 @@ public final class FedoraServiceTest {
         MockitoAnnotations.initMocks(this);
 
         fedoraService.setRepositoryView(new RepositoryView(RepositoryViewType.FEDORA, "Mock Fedora", "http://localhost:9100/mock/fcrepo/rest"));
+
+        mockTriple1 = new Triple();
+        mockTriple1.setSubject(TEST_SUBJECT.toString());
+        mockTriple1.setPredicate(TEST_PREDICATE.toString());
+        mockTriple1.setObject(TEST_OBJECT_1);
+
+        mockTriple2 = new Triple();
+        mockTriple2.setSubject(TEST_SUBJECT.toString());
+        mockTriple2.setPredicate(TEST_PREDICATE.toString());
+        mockTriple2.setObject(TEST_OBJECT_2);
     }
 
     @Test
@@ -78,6 +104,29 @@ public final class FedoraServiceTest {
     public void getVersions() throws Exception {
         List<Version> versions = fedoraService.getVersions(TEST_CONTEXT_URI);
         assertVersions(versions);
+    }
+
+    @Test
+    public void metadataListSize() throws Exception {
+        RepositoryViewContext context = fedoraService.createMetadata(TEST_CONTEXT_URI, mockTriple1);
+
+        context.addMetadatum(mockTriple1);
+        context.addMetadatum(mockTriple2);
+
+        List<Triple> metadata = context.getMetadataList();
+
+        assertEquals(2, metadata.size(), "Context had incorrect metadata list size!");
+    }
+
+    @Test
+    public void propertyListSize() throws Exception {
+        RepositoryViewContext context = fedoraService.createMetadata(TEST_CONTEXT_URI, mockTriple1);
+
+        context.addProperty(mockTriple1);
+
+        List<Triple> properties = context.getPropertiesList();
+
+        assertEquals(10, properties.size(), "Context had incorrect properties list size!");
     }
 
     private void assertVersions(List<Version> versions) {


### PR DESCRIPTION
The changes:
1. Redesign context triple's property and metadata structure.
2. Implement expanding/collapsing for individual triple sets.
3. Restructure the CSS to allow for an acceptable placement of expanding/collapsing icons in a responsive way.
4. Fix the spelling of 'expand'.

**About 1**
The frontend will loop over the context properties and metadata, generating a map file for each.
These map files will be utilized in the ng-repeat.

**About 3**
There is no good place for the collapse/expand glyphicon.
The best place I could come up with would be in the middle area between the predicate and its value.
Making this change required adding additional padding.
The exiting responsiveness behavior changes how the predicate label is display and as such the collapse/expand glyphicon must be changed with it.
The predicate label does not play well in its default structure of 'block' with the glyicon next to it and so the predicate label has been forcibly changed to 'inline'.