### PR TITLE
Item B-03904: Maintain bi-directional support

### DIFF
--- a/src/main/webapp/app/controllers/repositoryViewContextController.js
+++ b/src/main/webapp/app/controllers/repositoryViewContextController.js
@@ -17,7 +17,7 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
   $scope.countPredicates = function(triples, predicates) {
     if (predicates) {
       angular.forEach(predicates, function (value, key) {
-        delete predicate[key];
+        delete predicates[key];
       });
     } else {
       predicates = {};

--- a/src/main/webapp/app/controllers/repositoryViewContextController.js
+++ b/src/main/webapp/app/controllers/repositoryViewContextController.js
@@ -6,10 +6,6 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
 
   $scope.repositoryViewForm = {};
 
-  $scope.triplePropertiesCollapsed = {};
-
-  $scope.tripleMetadataCollapsed = {};
-
   $scope.submitClicked = false;
 
   $scope.theaterMode = false;
@@ -18,17 +14,22 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
     $scope.theaterMode = mode ? mode : !$scope.theaterMode;
   };
 
-  $scope.mapTriplesByPredicate = function(triples) {
-    var map = {};
+  $scope.countPredicates = function(triples, predicates) {
+    if (predicates) {
+      angular.forEach(predicates, function (value, key) {
+        delete predicate[key];
+      });
+    } else {
+      predicates = {};
+    }
+
     angular.forEach(triples, function (triple) {
-        if (!map.hasOwnProperty(triple.predicate)) {
-          map[triple.predicate] = [];
+        if (!predicates.hasOwnProperty(triple.predicate)) {
+          predicates[triple.predicate] = 0;
         }
 
-        map[triple.predicate].push(triple);
+        predicates[triple.predicate]++;
     });
-
-    return map;
   };
 
   RepositoryViewRepo.ready().then(function () {
@@ -44,6 +45,14 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
     }
 
     $scope.context = $scope.repositoryView.loadContext($scope.repositoryView.contextUri);
+
+    $scope.context.propertiesCollapsed = {};
+
+    $scope.context.metadataCollapsed = {};
+
+    $scope.context.propertiesPredicateTotals = {};
+
+    $scope.context.metadataPredicateTotals = {};
 
     $scope.createContainer = function (form) {
       $scope.submitClicked = true;

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -121,15 +121,15 @@
             <span class="glyphicon glyphicon-plus clickable" ng-click="propertiesCollapsed=false" ng-show="(!context.resource||theaterMode)&&propertiesCollapsed"></span>
             <span class="glyphicon glyphicon-minus clickable" ng-click="propertiesCollapsed=true" ng-show="(!context.resource||theaterMode)&&!propertiesCollapsed"></span>
           </h4>
-          <div class="context-property" ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)" ng-if="context.properties" ng-init="map = mapTriplesByPredicate(context.properties)">
-            <dl class="dl-horizontal" ng-repeat="(predicate, property) in map">
+          <div class="context-property" ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)" ng-if="context.properties" ng-init="countPredicates(context.properties, context.propertiesPredicateTotals)">
+            <dl class="dl-horizontal" ng-repeat="(predicate, totalTriples) in context.propertiesPredicateTotals">
               <dt class="property-term">
                 <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
               </dt>
-              <span title="expand {{predicate | metadataLabel}}" class="glyphicon glyphicon-plus clickable property-collapsable" ng-if="property.length > 1" ng-click="triplePropertiesCollapsed[predicate]=false" ng-show="triplePropertiesCollapsed[predicate]"></span>
-              <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable property-collapsable" ng-if="property.length > 1" ng-click="triplePropertiesCollapsed[predicate]=true" ng-show="!triplePropertiesCollapsed[predicate]"></span>
-              <dd ng-repeat="triple in property">
-                <span ng-show="!triplePropertiesCollapsed[predicate]" >{{triple.object | propertyValue}}</span>
+              <span title="expand {{predicate | metadataLabel}}" class="glyphicon glyphicon-plus clickable property-collapsable" ng-if="totalTriples > 1" ng-click="context.propertiesCollapsed[predicate]=false" ng-show="context.propertiesCollapsed[predicate]"></span>
+              <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable property-collapsable" ng-if="totalTriples > 1" ng-click="context.propertiesCollapsed[predicate]=true" ng-show="!context.propertiesCollapsed[predicate]"></span>
+              <dd ng-repeat="triple in context.properties | filter:{ predicate: predicate }: true">
+                <span ng-show="!context.propertiesCollapsed[predicate]">{{triple.object | propertyValue}}</span>
               </dd>
             </dl>
           </div>
@@ -139,31 +139,31 @@
 
     </div>
 
-    <div class="row metadata-section" ng-if="context.metadata" ng-init="map = mapTriplesByPredicate(context.metadata)">
+    <div class="row metadata-section" ng-if="context.metadata" ng-init="countPredicates(context.metadata, context.metadataPredicateTotals)">
       <repository-view-section
         context="context"
         title="'Metadata'"
         type="'metadatum'"
-        list="map"
+        list="context.metadata"
         list-element-action="repositoryView.loadContext(le)"
         add-action="openModal('#addMetadata')"
         edit-action="updateMetadatum(triple,newObject)"
         remove-action="context.removeMetadata(items)">
         <br ng-show="contentExpanded">
-        <dl class="dl-horizontal context-metadata" ng-show="contentExpanded" ng-repeat="(predicate, metadata) in list">
+        <dl class="dl-horizontal context-metadata" ng-show="contentExpanded" ng-repeat="(predicate, totalTriples) in context.metadataPredicateTotals">
           <dt class="metadata-term">
             <input ng-show="removeListElements&&filteredList.length>1" type="checkbox" ng-checked="checkAll" ng-click="checkAll=!checkAll;checkAll?selectAll(filteredList):selectedListElements.length=0">
             <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
           </dt>
-          <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable metadata-collapsable" ng-if="metadata.length > 1" ng-click="context.tripleMetadataCollapsed[predicate]=true" ng-show="!context.tripleMetadataCollapsed[predicate]"></span>
-          <span title="expand {{predicate | metadataLabel}}"  class="glyphicon glyphicon-plus clickable metadata-collapsable" ng-if="metadata.length > 1" ng-click="context.tripleMetadataCollapsed[predicate]=false" ng-show="context.tripleMetadataCollapsed[predicate]"></span>
-          <dd ng-mouseenter="showEditBtn=true" ng-mouseleave="showEditBtn=false" ng-repeat="triple in metadata">
+          <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable metadata-collapsable" ng-if="totalTriples > 1" ng-click="context.metadataCollapsed[predicate]=true" ng-show="!context.metadataCollapsed[predicate]"></span>
+          <span title="expand {{predicate | metadataLabel}}"  class="glyphicon glyphicon-plus clickable metadata-collapsable" ng-if="totalTriples > 1" ng-click="context.metadataCollapsed[predicate]=false" ng-show="context.metadataCollapsed[predicate]"></span>
+          <dd ng-mouseenter="showEditBtn=true" ng-mouseleave="showEditBtn=false" ng-repeat="triple in context.metadata | filter:{ predicate: predicate }: true">
             <input ng-show="removeListElements" type="checkbox" ng-checked="selectedListElements.indexOf(triple)!==-1" ng-click="selectedListElements.indexOf(triple)===-1?selectedListElements.push(triple):selectedListElements.splice(selectedListElements.indexOf(triple),1)">
             <span ng-show="!editValue&&selectedListElements.indexOf(triple)===-1">
-              <span ng-show="!context.tripleMetadataCollapsed[predicate]">{{triple.object | removeQuotes}}</span>
-              <span class="glyphicon glyphicon-pencil clickable" ng-click="editValue=triple.object" ng-show="showEditBtn && !context.isVersion && !context.tripleMetadataCollapsed[predicate]" ></span>
+              <span ng-show="!context.metadataCollapsed[predicate]">{{triple.object | removeQuotes}}</span>
+              <span class="glyphicon glyphicon-pencil clickable" ng-click="editValue=triple.object" ng-show="showEditBtn && !context.isVersion && !context.metadataCollapsed[predicate]" ></span>
             </span>
-            <div ng-show="editValue && !context.tripleMetadataCollapsed[predicate]" class="row">
+            <div ng-show="editValue && !context.metadataCollapsed[predicate]" class="row">
               <div class="col-md-6">
                   <div class="input-group">
                     <input type="text" class="form-control" ng-model="editValue" remove-quotes>


### PR DESCRIPTION
My preferred design of using an array map is not achievable due to the loss of bi-directional support.
This means that create, update, and delete do not refresh as desired.

As a compromise, partially revert the original behavior of looping over the triple set while applying a filter on the predicate.

Unlike the original design, this utilizes a count map representing the total triples per predicate.
This count map is iterated over in the outer loop instead of iterating the entire triple set.
The inner loop utilizes the original behavior by looping over the entire triples set and applying a filter against the predicate.

Though the design is not ideal, it preserves the bi-directional mapping, provides the requested feature, and does not require major design changes in back-end or front-end.