### PR TITLE
Item B-03902: As a curator, I would like to see all the metadata, even for unassociated schemata

### DIFF
--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -578,6 +578,8 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
                     for (String prefix : repositoryView.getMetadataPrefixes()) {
                         if (predicate.startsWith(prefix)) {
                             repositoryViewContext.addMetadum(triple);
+                        } else {
+                            repositoryViewContext.addProperty(triple);
                         }
                     }
                 }

--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -580,7 +580,7 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
 
                     for (String prefix : repositoryView.getMetadataPrefixes()) {
                         if (predicate.startsWith(prefix)) {
-                            repositoryViewContext.addMetadum(triple);
+                            repositoryViewContext.addMetadatum(triple);
                             unassociatedPredicate = false;
                             break;
                         }

--- a/src/main/java/edu/tamu/cap/service/FedoraService.java
+++ b/src/main/java/edu/tamu/cap/service/FedoraService.java
@@ -568,19 +568,26 @@ public class FedoraService implements RepositoryViewService<Model>, VersioningRe
                     }
                     break;
                 default:
+                    boolean unassociatedPredicate = true;
 
                     for (String prefix : PROPERTY_PREFIXES) {
                         if (predicate.startsWith(prefix)) {
                             repositoryViewContext.addProperty(triple);
+                            unassociatedPredicate = false;
+                            break;
                         }
                     }
 
                     for (String prefix : repositoryView.getMetadataPrefixes()) {
                         if (predicate.startsWith(prefix)) {
                             repositoryViewContext.addMetadum(triple);
-                        } else {
-                            repositoryViewContext.addProperty(triple);
+                            unassociatedPredicate = false;
+                            break;
                         }
+                    }
+
+                    if (unassociatedPredicate) {
+                        repositoryViewContext.addProperty(triple);
                     }
                 }
             }

--- a/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
+++ b/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
@@ -109,24 +109,27 @@ public final class FedoraServiceTest {
     @Test
     public void metadataListSize() throws Exception {
         RepositoryViewContext context = fedoraService.createMetadata(TEST_CONTEXT_URI, mockTriple1);
+        int initialSize = context.getMetadata().size();
 
         context.addMetadatum(mockTriple1);
         context.addMetadatum(mockTriple2);
 
         List<Triple> metadata = context.getMetadata();
 
-        assertEquals(2, metadata.size(), "Context had incorrect metadata list size!");
+        assertEquals(initialSize + 2, metadata.size(), "Context had incorrect metadata list size!");
     }
 
     @Test
     public void propertyListSize() throws Exception {
         RepositoryViewContext context = fedoraService.createMetadata(TEST_CONTEXT_URI, mockTriple1);
+        int initialSize = context.getProperties().size();
 
         context.addProperty(mockTriple1);
+        context.addProperty(mockTriple2);
 
         List<Triple> properties = context.getProperties();
 
-        assertEquals(10, properties.size(), "Context had incorrect properties list size!");
+        assertEquals(initialSize + 2, properties.size(), "Context had incorrect properties list size!");
     }
 
     private void assertVersions(List<Version> versions) {


### PR DESCRIPTION
The unassociated schemata are being added in the properties as other approaches likely involve changes to the API.

This is the simplest approach to solving the card as closely as possible without API changes.