### PR TITLE
[B-03706] URI context query param should be path/handle instead of full URL

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -228,9 +228,11 @@
 
   <!-- filters -->
   <script src="filters/contextFilter.js"></script>
+  <script src="filters/lengthenUriFilter.js"></script>
   <script src="filters/metadataLabelFilter.js"></script>
   <script src="filters/mapPropertiesFilter.js"></script>
   <script src="filters/removeQuotesFilter.js"></script>
+  <script src="filters/shortenUriFilter.js"></script>
   <script src="filters/uniqueFilter.js"></script>
   <script src="filters/containedInFilter.js"></script>
   <script src="filters/propertyValueFilter.js"></script>

--- a/src/main/webapp/app/controllers/repositoryViewContextController.js
+++ b/src/main/webapp/app/controllers/repositoryViewContextController.js
@@ -15,7 +15,6 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
   };
 
   RepositoryViewRepo.ready().then(function () {
-
     $scope.repositoryView = RepositoryViewRepo.findByName(decodeURI($routeParams.irName));
 
     if(!$scope.repositoryView) $location.path("/error/404");
@@ -313,5 +312,9 @@ cap.controller("IrContextController", function ($controller, $location, $routePa
     $scope.resetUploadResource();
 
   });
+
+  $scope.lengthenContextUri = function (contextUri) {
+    return $scope.context.repositoryView.rootUri ? $filter('lengthenUri')(contextUri, $scope.context.repositoryView.rootUri) : contextUri;
+  };
 
 });

--- a/src/main/webapp/app/directives/breadcrumbDirective.js
+++ b/src/main/webapp/app/directives/breadcrumbDirective.js
@@ -1,4 +1,4 @@
-cap.directive("breadcrumbs", function() {
+cap.directive("breadcrumbs", function($filter) {
     return {
         templateUrl: "views/directives/breadcrumbs.html",
         restrict: "E",
@@ -15,7 +15,7 @@ cap.directive("breadcrumbs", function() {
               }
               if(index) {
                 var prev = $scope.breadcrumbs.length > 0 ? $scope.breadcrumbs[index - 1] : undefined;
-                
+
                 if(prev && !context.isVersion) {
                   var prevName = prev.name.replace(context.repositoryView.rootUri, '...');
                   name = name.replace(prevName, '...');
@@ -30,6 +30,10 @@ cap.directive("breadcrumbs", function() {
                 }
               }
               return name;
+            };
+
+            $scope.shortenBreadcrumbUri = function (breadcrumb) {
+              return breadcrumb.repositoryView.rootUri ? $filter('shortenUri')(breadcrumb.uri, breadcrumb.repositoryView.rootUri) : breadcrumb.uri;
             };
 
             var getParent = function(context) {

--- a/src/main/webapp/app/filters/lengthenUriFilter.js
+++ b/src/main/webapp/app/filters/lengthenUriFilter.js
@@ -1,0 +1,20 @@
+cap.filter('lengthenUri', function () {
+  return function (shortUri, rootUri) {
+    var longUri = shortUri;
+
+    // utilize new URL() throwing an exception when contextUri is not a full URI to determine if a long/full URL needs to be generated.
+    try {
+      new URL(shortUri);
+    } catch (_) {
+      if (rootUri.length > 0) {
+        if (rootUri[rootUri.length - 1] == "/" || rootUri[rootUri.length - 1] == "#") {
+          longUri = shortUri.length > 0 && shortUri[0] == "/" ? rootUri + shortUri.substring(1) : rootUri + shortUri;
+        } else {
+          longUri = shortUri.length > 0 && shortUri[0] == "/" ? rootUri + shortUri : rootUri + "/" + shortUri;
+        }
+      }
+    }
+
+    return longUri;
+  };
+});

--- a/src/main/webapp/app/filters/shortenUriFilter.js
+++ b/src/main/webapp/app/filters/shortenUriFilter.js
@@ -1,0 +1,16 @@
+cap.filter('shortenUri', function () {
+  return function (longUri, baseUri) {
+    var shortUri = longUri;
+
+    if (longUri.indexOf(baseUri) !== -1) {
+      var parts = longUri.split(baseUri, 2);
+      shortUri = parts[1] ? parts[1] : '';
+    }
+
+    if (shortUri[0] == '/') {
+      shortUri = shortUri.substring(1);
+    }
+
+    return shortUri;
+  };
+});

--- a/src/main/webapp/app/model/repositoryViewContext.js
+++ b/src/main/webapp/app/model/repositoryViewContext.js
@@ -5,11 +5,15 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
 
     var children = {};
 
+    var shortenContextUri = function (contextUri) {
+      return repositoryViewContext.repositoryView.rootUri ? $filter('shortenUri')(contextUri, repositoryViewContext.repositoryView.rootUri) : contextUri;
+    };
+
     var fetchContext = function (contextUri) {
       return repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().load, {
         method: HttpMethodVerbs.GET,
         query: {
-          contextUri: contextUri
+          contextUri: shortenContextUri(contextUri)
         }
       });
     };
@@ -49,7 +53,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
         });
       });
       return reloadPromise;
-    }; 
+    };
 
     repositoryViewContext.getChildContext = function (triple) {
       if (!children[triple.object]) {
@@ -81,7 +85,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
       var createPromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().children, {
         method: HttpMethodVerbs.POST,
         query: {
-          contextUri: repositoryViewContext.uri
+          contextUri: shortenContextUri(repositoryViewContext.uri)
         },
         data: metadata
       });
@@ -101,7 +105,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
         var removePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().load, {
           method: HttpMethodVerbs.DELETE,
           query: {
-            contextUri: containerTriple.subject
+            contextUri: shortenContextUri(containerTriple.subject)
           }
         });
 
@@ -134,7 +138,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
         var removePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().resource, {
           method: HttpMethodVerbs.DELETE,
           query: {
-            contextUri: resourceTriple.subject
+            contextUri: shortenContextUri(resourceTriple.subject)
           }
         });
 
@@ -163,14 +167,14 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
 
       var formData = new FormData();
       formData.append("file", file, file.name);
-      
+
       var createPromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().resource, {
         method: HttpMethodVerbs.POST,
         headers: {
           "Content-Type": undefined
         },
         query: {
-          contextUri: repositoryViewContext.uri
+          contextUri: shortenContextUri(repositoryViewContext.uri)
         },
         data: formData
       });
@@ -190,7 +194,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
         var createPromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().metadata, {
           method: HttpMethodVerbs.POST,
           query: {
-            contextUri: repositoryViewContext.uri
+            contextUri: shortenContextUri(repositoryViewContext.uri)
           },
           data: metadataTriple
         });
@@ -216,7 +220,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
         var removePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().metadata, {
           method: HttpMethodVerbs.DELETE,
           query: {
-            contextUri: repositoryViewContext.uri
+            contextUri: shortenContextUri(repositoryViewContext.uri)
           },
           data: metadataTriple
         });
@@ -237,16 +241,16 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
     };
 
     repositoryViewContext.updateMetadatum = function (metadataTriple, newValue) {
-      
+
       var updatePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().metadata, {
         method: HttpMethodVerbs.PUT,
         query: {
-          contextUri: repositoryViewContext.uri,
+          contextUri: shortenContextUri(repositoryViewContext.uri),
           newValue: newValue
         },
         data: metadataTriple
       });
-      
+
       return updatePromise;
 
     };
@@ -256,7 +260,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
       var versionPromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().version, {
         method: HttpMethodVerbs.POST,
         query: {
-          contextUri: repositoryViewContext.uri
+          contextUri: shortenContextUri(repositoryViewContext.uri)
         },
         data: {
           name: form.name
@@ -282,7 +286,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
       return repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().version, {
         method: HttpMethodVerbs.DELETE,
         query: {
-          contextUri: versionContext.uri
+          contextUri: shortenContextUri(versionContext.uri)
         }
       });
     };
@@ -291,7 +295,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
       var revertVersionPromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().version, {
         method: HttpMethodVerbs.PATCH,
         query: {
-          contextUri: context.uri
+          contextUri: shortenContextUri(context.uri)
         }
       });
       return revertVersionPromise;
@@ -301,7 +305,7 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
       var updatePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().advancedQuery, {
         method: HttpMethodVerbs.POST,
         query: {
-          contextUri: repositoryViewContext.uri
+          contextUri: shortenContextUri(repositoryViewContext.uri)
         },
         data: query
       });
@@ -318,14 +322,14 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
     repositoryViewContext.getQueryHelp = function () {
 
       if(!queryHelp.message) {
-        
+
         var updatePromise = repositoryViewContext.repositoryView.performRequest(repositoryViewContext.getMapping().advancedQuery, {
           method: HttpMethodVerbs.GET,
           query: {
-            contextUri: repositoryViewContext.uri
+            contextUri: shortenContextUri(repositoryViewContext.uri)
           }
         });
-  
+
         updatePromise.then(function (res) {
           queryHelp.query = angular.fromJson(res.body).payload.String;
         });
@@ -335,6 +339,5 @@ cap.model("RepositoryViewContext", function ($q, $filter, $interval, $location, 
     };
 
     return this;
-
   };
 });

--- a/src/main/webapp/app/model/repositoryViewModel.js
+++ b/src/main/webapp/app/model/repositoryViewModel.js
@@ -1,25 +1,29 @@
-cap.model("RepositoryView", function($location, $timeout, $cookies, $interval, $q, HttpMethodVerbs, RepositoryViewContext, WsApi, StorageService, UserService) {
+cap.model("RepositoryView", function($location, $timeout, $cookies, $filter, $interval, $q, HttpMethodVerbs, RepositoryViewContext, WsApi, StorageService, UserService) {
   return function RepositoryView() {
     var repositoryView = this;
 
     var cache = {};
 
+    var lengthenContextUri = function (contextUri) {
+      return repositoryView.rootUri ? $filter('lengthenUri')(contextUri, repositoryView.rootUri) : contextUri;
+    };
+
     repositoryView.currentContext = {};
 
     repositoryView.cacheContext = function(context) {
-      cache[context.uri] = context;
+      cache[lengthenContextUri(context.uri)] = context;
     };
 
     repositoryView.getCachedContext = function(contextUri) {
-      return cache[contextUri];
+      return cache[lengthenContextUri(contextUri)];
     };
 
     repositoryView.removeCachedContext = function(contextUri) {
-      delete cache[contextUri];
+      delete cache[lengthenContextUri(contextUri)];
     };
 
     repositoryView.clearCache = function() {
-      angular.forEach(cache, function(v,uri){
+      angular.forEach(cache, function(v, uri){
         repositoryView.removeCachedContext(uri);
       });
     };
@@ -35,8 +39,9 @@ cap.model("RepositoryView", function($location, $timeout, $cookies, $interval, $
         console.log(context.repositoryView);
         repositoryView.cacheContext(context);
       } else if(reload) {
-       context.reloadContext();
+        context.reloadContext();
       }
+
       return context;
     };
 
@@ -58,7 +63,7 @@ cap.model("RepositoryView", function($location, $timeout, $cookies, $interval, $
       } else {
         options.pathValues = defaultPathValues;
       }
-      
+
       return WsApi.fetch(endpoint, options);
 
     };
@@ -160,7 +165,7 @@ cap.model("RepositoryView", function($location, $timeout, $cookies, $interval, $
     };
 
     repositoryView.getTransaction = function() {
-      var transactionCookie = $cookies.getObject("transaction"); 
+      var transactionCookie = $cookies.getObject("transaction");
       if(transactionCookie)  {
         transactionObject.active = true;
       } else {
@@ -187,7 +192,7 @@ cap.model("RepositoryView", function($location, $timeout, $cookies, $interval, $
           var secondsremaining = transaction.secondsRemaining-1;
 
           repositoryView.createTransactionCookie(transaction.transactionToken, secondsremaining);
-          
+
           if(repositoryView.getTransaction().secondsRemaining<1) {
            repositoryView.stopTransactionTimer();
           }

--- a/src/main/webapp/app/views/admin/repositoryViewManagement.html
+++ b/src/main/webapp/app/views/admin/repositoryViewManagement.html
@@ -31,7 +31,7 @@
               <span class="badge clickable" ng-click="showSchemas(repositoryView.schemas)">{{repositoryView.schemas.length || 0}}</span>
             </td>
             <td data-title="'Actions'" class="actions">
-                <a href="rv/{{repositoryView.name}}?context={{repositoryView.rootUri}}" title="view" class="glyphicon glyphicon-eye-open action"></a>
+                <a href="rv/{{repositoryView.name}}?context=" title="view" class="glyphicon glyphicon-eye-open action"></a>
                 <span ng-if="isAdmin()" title="edit" ng-click="editRepositoryView(repositoryView)" class="glyphicon glyphicon-pencil action"></span>
                 <span ng-if="isAdmin()" title="delete" ng-click="confirmDeleteRepositoryView(repositoryView)" class="glyphicon glyphicon-trash action"></span>
             </td>

--- a/src/main/webapp/app/views/directives/breadcrumbs.html
+++ b/src/main/webapp/app/views/directives/breadcrumbs.html
@@ -1,6 +1,6 @@
 <ol class="breadcrumb">
     <li ng-repeat="breadcrumb in breadcrumbs track by $index">
-        <a href="" ng-click="breadcrumb.repositoryView.loadContext(breadcrumb.uri)">{{trimName(breadcrumb, $index)}}</a>
+        <a href="" ng-click="breadcrumb.repositoryView.loadContext(shortenBreadcrumbUri(breadcrumb))">{{trimName(breadcrumb, $index)}}</a>
     </li>
     <br ng-if="breadcrumbs.length" />
     <li class="active">

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -48,7 +48,7 @@
 
       </ul>
     </div>
-    <h1>{{repositoryView.name}} <small class="clickable" ng-click="repositoryView.loadContext(repositoryView.rootUri)">(<span class="glyphicon glyphicon-home"></span> {{repositoryView.rootUri}})</small></h1>
+    <h1>{{repositoryView.name}} <small class="clickable" ng-click="repositoryView.loadContext('')">(<span class="glyphicon glyphicon-home"></span> {{repositoryView.rootUri}})</small></h1>
   </div>
 
   <breadcrumbs ng-if="context.hasParent !== undefined" context="context"></breadcrumbs>
@@ -80,7 +80,7 @@
       <div class="row">
         <div class="preview" ng-class="{'col-md-6 col-md-push-6': !theaterMode, 'col-md-12': theaterMode}" ng-if="context.resource">
           <div class="thumbnail" ng-mouseover="showImageControls=true" ng-mouseleave="showImageControls=false" >
-            <contentviewer content-type="getContentType()" resource="context.uri" ng-if="context.resource"></contentviewer>
+            <contentviewer content-type="getContentType()" resource="lengthenContextUri(context.uri)" ng-if="context.resource"></contentviewer>
             <div class="image-controls" ng-show="showImageControls">
               <div class="image-control">
                   <span class="glyphicon glyphicon-resize-horizontal" ng-click="setOrToggleTheaterMode()"></span>
@@ -101,13 +101,13 @@
                     <li role="menuitem" class="disabled"><a href="#">Send to Magpie</a></li>
                     <li role="menuitem" class="disabled"><a href="#">Create thumbnail</a></li>
                     <li role="menuitem" class="disabled"><a href="#">View in Mirador</a></li>
-                    <li role="menuitem"><a href="" ng-click="copyToClipboard(context.uri, 'contextUri')">Copy Resource URL</a></li>
+                    <li role="menuitem"><a href="" ng-click="copyToClipboard(lengthenContextUri(context.uri), 'contextUri')">Copy Resource URL</a></li>
                     <li ng-if="getIIIFUrl()" role="menuitem"><a href="" ng-click="copyToClipboard(getIIIFUrl(), 'contextUri')">Copy IIIF Manifest URL</a></li>
                   </ul>
                 </div>
               </div>
               <div class="pull-right">
-                <a href="{{context.uri}}" download class="btn btn-primary" role="button"><span class="glyphicon glyphicon-download-alt"></span> Download</a>
+                <a href="{{lengthenContextUri(context.uri)}}" download class="btn btn-primary" role="button"><span class="glyphicon glyphicon-download-alt"></span> Download</a>
                 <a ng-if="context.features.fixity" href="" ng-click="openFixity(context.triple.subject)" class="btn btn-default" role="button"><span class="glyphicon glyphicon-ok"></span> Fixity</a>
               </div>
             </div>
@@ -192,7 +192,7 @@
         remove-action="context.removeContainers(items)">
         <ol class="list-group" ng-show="contentExpanded">
           <li  class="list-group-item" ng-repeat="le in filteredList = (list | filterContainers:context | orderBy: 'name')" ng-class="{'list-group-item-danger': selectedListElements.indexOf(le.triple)!==-1}">
-            <a href="" ng-click="listElementAction({'le':le.triple.subject})">{{(le.name || le.triple.object) | removeQuotes}}</a>
+            <a href="" ng-click="listElementAction({'le': (le.triple.subject | shortenUri: context.repositoryView.rootUri)})">{{(le.name || le.triple.object) | removeQuotes}}</a>
             <input ng-show="removeListElements" type="checkbox" class="pull-right" ng-checked="selectedListElements.indexOf(le.triple)!==-1" ng-click="selectedListElements.indexOf(le.triple)===-1?selectedListElements.push(le.triple):selectedListElements.splice(selectedListElements.indexOf(le.triple),1)">
           </li>
         </ol>
@@ -210,7 +210,7 @@
         remove-action="context.removeResources(items)">
         <ol class="list-group" ng-show="contentExpanded">
           <li  class="list-group-item" ng-repeat="le in filteredList = (list | filterResources:context | orderBy: 'name') track by $index" ng-class="{'list-group-item-danger': selectedListElements.indexOf(le.triple)!==-1}">
-            <a href="" ng-click="listElementAction({'le':le.triple.subject})">{{(le.name || le.triple.object) | removeQuotes}}</a>
+            <a href="" ng-click="listElementAction({'le': (le.triple.subject | shortenUri: context.repositoryView.rootUri)})">{{(le.name || le.triple.object) | removeQuotes}}</a>
             <!--<a href="" ng-show="!removeListElements" ng-click="resourceToUpdate=le;openModal('#updateResourceModalModal'+$index)"><span title="swap" class="glyphicon glyphicon-transfer pull-right clickable"></span></a>-->
             <a href="" ng-show="!removeListElements" ng-click="contextScope.openFixity(le.triple.subject)"><span title="fixity" class="glyphicon glyphicon-check pull-right clickable"></span></a>
             <a href="{{le.triple.subject}}" download><span ng-show="!removeListElements" title="download" class="glyphicon glyphicon-download-alt pull-right"></span></a>

--- a/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
+++ b/src/test/java/edu/tamu/cap/service/FedoraServiceTest.java
@@ -38,7 +38,8 @@ public final class FedoraServiceTest {
 
     private final static String TEST_VERSION2_NAME = "TestVersion2";
 
-    private final static String TEST_CONTEXT_URI = ROOT_CONTEXT_URI + "/path/to/container";
+    private final static String TEST_CONTEXT_URI_SHORT = "path/to/container";
+    private final static String TEST_CONTEXT_URI = ROOT_CONTEXT_URI + "/" + TEST_CONTEXT_URI_SHORT;
 
     private HttpServletRequest request;
 
@@ -75,8 +76,20 @@ public final class FedoraServiceTest {
     }
 
     @Test
+    public void createVersionShortUri() throws Exception {
+        RepositoryViewContext context = fedoraService.createVersion(TEST_CONTEXT_URI_SHORT, TEST_VERSION1_NAME);
+        assertVersions(context.getVersions());
+    }
+
+    @Test
     public void getVersions() throws Exception {
         List<Version> versions = fedoraService.getVersions(TEST_CONTEXT_URI);
+        assertVersions(versions);
+    }
+
+    @Test
+    public void getVersionsShortUri() throws Exception {
+        List<Version> versions = fedoraService.getVersions(TEST_CONTEXT_URI_SHORT);
         assertVersions(versions);
     }
 
@@ -85,13 +98,13 @@ public final class FedoraServiceTest {
 
         assertEquals(TEST_VERSION1_NAME, versions.get(0).getName(), "Version 1 had the incorrect name!");
         assertEquals("2018-03-21T19:43:34.573Z^^http://www.w3.org/2001/XMLSchema#dateTime", versions.get(0).getTime(), "Version 1 had the incorrect time!");
-        assertEquals("http://localhost:9100/mock/fcrepo/rest/path/to/container/fcr:versions", versions.get(0).getTriple().getSubject(), "Version 1 had the incorrect subject!");
+        assertEquals(TEST_CONTEXT_URI + "/fcr:versions", versions.get(0).getTriple().getSubject(), "Version 1 had the incorrect subject!");
         assertEquals("http://fedora.info/definitions/v4/repository#hasVersion", versions.get(0).getTriple().getPredicate(), "Version 1 had the incorrect object!");
         assertEquals("http://localhost:9100/mock/fcrepo/rest/path/to/container/fcr:versions/TestVersion1", versions.get(0).getTriple().getObject(), "Version 1 had the incorrect predicate!");
 
         assertEquals(TEST_VERSION2_NAME, versions.get(1).getName(), "Version 2 had the incorrect name!");
         assertEquals("2018-03-21T19:44:48.852Z^^http://www.w3.org/2001/XMLSchema#dateTime", versions.get(1).getTime(), "Version 2 had the incorrect time!");
-        assertEquals("http://localhost:9100/mock/fcrepo/rest/path/to/container/fcr:versions", versions.get(1).getTriple().getSubject(), "Version 2 had the incorrect subject!");
+        assertEquals(TEST_CONTEXT_URI + "/fcr:versions", versions.get(1).getTriple().getSubject(), "Version 2 had the incorrect subject!");
         assertEquals("http://fedora.info/definitions/v4/repository#hasVersion", versions.get(1).getTriple().getPredicate(), "Version 2 had the incorrect object!");
         assertEquals("http://localhost:9100/mock/fcrepo/rest/path/to/container/fcr:versions/TestVersion2", versions.get(1).getTriple().getObject(), "Version 2 had the incorrect predicate!");
     }


### PR DESCRIPTION
On the backend,
- Accept both long and short context URIs.
- Ensure triple subjects use long context URIs.
- Ensure double-slashes do not happen.

On the frontend,
- Add lengthen and shorten URI/URL filters.
- Replace URL parameters for both 'context' and 'context uri' with short URLs.
- Use short URL for triple subjects.
- `repositoryView.loadContext()` does not accept null parameters; provide an empty string for when viewing the root of a Repository View.
- Ensure long URIs/URLs are still used for caches.
- Ensure double-slashes do not happen.

Implementation concerns,
- The use of `new URL()` in front-end avoids writing custom processing code but assumes that the URI is only a URL.
- Building and using the long URI as the cache key instead of the short URI.
- Using empty context on repository view root when it could be changed to not have context parameter specified at all (may require backend changes to implement this).
- Are there better words than lengthen/long shorten/short for URI?