### PR TITLE
[B03904] preserve collapse related settings when remove metadata is enabled

### DIFF
--- a/src/main/webapp/app/directives/repositoryViewSectionDirective.js
+++ b/src/main/webapp/app/directives/repositoryViewSectionDirective.js
@@ -110,6 +110,7 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
             return l;
           };
 
+          // TODO: provide a better solution than using a watch or remove entirely if adding manual refresh buttons.
           $scope.$watch("list", function(newList, oldList) {
             if (oldList !== undefined) {
               if (newList.length == oldList.length) {

--- a/src/main/webapp/app/directives/repositoryViewSectionDirective.js
+++ b/src/main/webapp/app/directives/repositoryViewSectionDirective.js
@@ -25,6 +25,8 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
             elem.find('.transclude').replaceWith(clone);
           });
 
+          $scope.checkedPredicates = {};
+
           $scope.selectedListElements = [];
 
           $scope.manuallyCollapse = function() {
@@ -39,6 +41,48 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
 
           $scope.selectAll = function(array) {
             angular.extend($scope.selectedListElements, array);
+          };
+
+          $scope.findByPredicate = function(predicate) {
+            var selectedList = [];
+
+            angular.forEach($scope.list, function(triple, key) {
+              if (triple.predicate === predicate) {
+                selectedList.push($scope.list[key]);
+              }
+            });
+
+            return selectedList;
+          };
+
+          $scope.checkPredicate = function(predicate) {
+            if ($scope.checkedPredicates[predicate]) {
+              $scope.checkedPredicates[predicate] = false;
+              $scope.unselectList();
+            } else {
+              $scope.checkedPredicates[predicate] = true;
+              $scope.selectByPredicate(predicate);
+            }
+
+            return $scope.checkedPredicates[predicate];
+          };
+
+          $scope.isPredicateChecked = function(predicate) {
+            return $scope.checkedPredicates[predicate] === true;
+          };
+
+          $scope.selectByPredicate = function(predicate) {
+            var selectedList = $scope.findByPredicate(predicate);
+
+            if (selectedList.length > 0) {
+              angular.extend($scope.selectedListElements, selectedList);
+              $scope.checkedPredicates[predicate] = true;
+            }
+          };
+
+          $scope.unselectList = function() {
+            $scope.checkedPredicates = {};
+            $scope.selectedListElements.length = 0;
           };
 
           $scope.confirmDelete = function() {
@@ -66,6 +110,20 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
             return l;
           };
 
+          $scope.$watch("list", function(newList, oldList) {
+            if (oldList !== undefined) {
+              if (newList.length == oldList.length) {
+                angular.forEach(oldList, function (value, key) {
+                  if (value != newList[key]) {
+                    $scope.unselectList();
+                  }
+                });
+              } else {
+                $scope.unselectList();
+              }
+            }
+          }, true);
+
           var un = $scope.$watchCollection("filteredList||list", function() {
             if($scope.getListLength()) {
               $scope.isArray = Array.isArray($scope.list);
@@ -73,7 +131,6 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
               un();
             }
           });
-
         }
     };
 });

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -165,7 +165,7 @@
             <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable metadata-collapsable" ng-if="totalTriples > 1" ng-click="context.metadataCollapsed[predicate]=true" ng-show="!context.metadataCollapsed[predicate]"></span>
             <span title="expand {{predicate | metadataLabel}}"  class="glyphicon glyphicon-plus clickable metadata-collapsable" ng-if="totalTriples > 1" ng-click="context.metadataCollapsed[predicate]=false" ng-show="context.metadataCollapsed[predicate]"></span>
             <dd ng-mouseenter="showEditBtn=true" ng-mouseleave="showEditBtn=false" ng-repeat="triple in context.metadata | filter: { predicate: predicate }: true">
-              <input ng-show="removeListElements" type="checkbox" ng-checked="selectedListElements.indexOf(triple)!==-1" ng-click="selectedListElements.indexOf(triple)===-1?selectedListElements.push(triple):selectedListElements.splice(selectedListElements.indexOf(triple),1)">
+              <input ng-show="removeListElements && !context.metadataCollapsed[predicate]" type="checkbox" ng-checked="selectedListElements.indexOf(triple)!==-1" ng-click="selectedListElements.indexOf(triple)===-1?selectedListElements.push(triple):selectedListElements.splice(selectedListElements.indexOf(triple),1)">
               <span ng-show="!editValue&&selectedListElements.indexOf(triple)===-1">
                 <span ng-show="!context.metadataCollapsed[predicate]">{{triple.object | removeQuotes}}</span>
                 <span class="glyphicon glyphicon-pencil clickable" ng-click="editValue=triple.object" ng-show="showEditBtn && !context.isVersion && !context.metadataCollapsed[predicate]" ></span>

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -188,7 +188,7 @@
                     </div>
                   </div>
               </div>
-              <del ng-if="removeListElements && selectedListElements.indexOf(triple)!==-1">{{triple.object | removeQuotes}}</del>
+              <del ng-if="removeListElements && selectedListElements.indexOf(triple)!==-1 && !context.metadataCollapsed[predicate]">{{triple.object | removeQuotes}}</del>
             </dd>
           </dl>
         </div>

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -159,7 +159,7 @@
           </h4>
           <dl class="dl-horizontal context-metadata" ng-show="!context.metadataCollapsedByNamespace[namespace]" ng-repeat="(predicate, totalTriples) in predicates">
             <dt class="metadata-term">
-              <input ng-show="removeListElements&&filteredList.length>1" type="checkbox" ng-checked="checkAll" ng-click="checkAll=!checkAll;checkAll?selectAll(filteredList):selectedListElements.length=0">
+              <input ng-show="removeListElements && totalTriples > 1" type="checkbox" ng-checked="isPredicateChecked(predicate)" ng-click="checkPredicate(predicate)">
               <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
             </dt>
             <span title="collapse {{predicate | metadataLabel}}" class="glyphicon glyphicon-minus clickable metadata-collapsable" ng-if="totalTriples > 1" ng-click="context.metadataCollapsed[predicate]=true" ng-show="!context.metadataCollapsed[predicate]"></span>


### PR DESCRIPTION
Per row delete checkbox should remain hidden when fields are collapsed.
The delete row text should also collapse when fields are collapsed.
Select all checkbox should appear per predicate.