### PR TITLE
[D-01255] Metadata on scope not updating when add/removed until page refresh

### DIFF
--- a/src/main/webapp/app/directives/repositoryViewSectionDirective.js
+++ b/src/main/webapp/app/directives/repositoryViewSectionDirective.js
@@ -11,7 +11,8 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
           listElementAction: "&",
           addAction: "&",
           removeAction: "&",
-          editAction: "&"
+          editAction: "&",
+          refreshAction: "&"
         },
         link: function($scope, elem, attr, ctrl, transclude) {
 
@@ -89,6 +90,10 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
             $scope.removeAction({"items": $scope.selectedListElements}).then(function() {
               $scope.removeListElements=false;
               $scope.selectedListElements.length=0;
+
+              if ($scope.refreshAction) {
+                $scope.refreshAction();
+              }
             });
           };
 
@@ -111,16 +116,25 @@ cap.directive("repositoryViewSection", function($controller, $timeout, Repositor
           };
 
           // TODO: provide a better solution than using a watch or remove entirely if adding manual refresh buttons.
+          // TODO: remove the manual refreshAction() calls once the broadcast on update is properly handled.
           $scope.$watch("list", function(newList, oldList) {
             if (oldList !== undefined) {
               if (newList.length == oldList.length) {
                 angular.forEach(oldList, function (value, key) {
                   if (value != newList[key]) {
                     $scope.unselectList();
+
+                    if ($scope.refreshAction) {
+                      $scope.refreshAction();
+                    }
                   }
                 });
               } else {
                 $scope.unselectList();
+
+                if ($scope.refreshAction) {
+                  $scope.refreshAction();
+                }
               }
             }
           }, true);

--- a/src/main/webapp/app/views/repositoryViewContext.html
+++ b/src/main/webapp/app/views/repositoryViewContext.html
@@ -122,7 +122,7 @@
             <span class="glyphicon glyphicon-plus clickable" ng-click="propertiesCollapsed=false" ng-show="(!context.resource||theaterMode)&&propertiesCollapsed"></span>
             <span class="glyphicon glyphicon-minus clickable" ng-click="propertiesCollapsed=true" ng-show="(!context.resource||theaterMode)&&!propertiesCollapsed"></span>
           </h4>
-          <div class="context-property" ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)" ng-if="context.properties" ng-init="countPredicates(context.properties, context.propertiesPredicateTotals)">
+          <div class="context-property" ng-show="!propertiesCollapsed||(context.resource&&!theaterMode)" ng-if="context.properties"">
             <dl class="dl-horizontal" ng-repeat="(predicate, totalTriples) in context.propertiesPredicateTotals">
               <dt class="property-term">
                 <a href="{{predicate}}">{{predicate | metadataLabel}}</a>
@@ -140,7 +140,7 @@
 
     </div>
 
-    <div class="row metadata-section" ng-if="context.metadata" ng-init="countPredicates(context.metadata, context.metadataPredicateTotals); groupPredicatesByNamespace(context.metadataPredicateTotals, context.metadataPredicatesByNamespace)">
+    <div class="row metadata-section" ng-if="context.metadata" ng-init="context.refreshMetadata()">
       <repository-view-section
         context="context"
         title="'Metadata'"
@@ -149,15 +149,16 @@
         list-element-action="repositoryView.loadContext(le)"
         add-action="openModal('#addMetadata')"
         edit-action="updateMetadatum(triple,newObject)"
-        remove-action="context.removeMetadata(items)">
+        remove-action="context.removeMetadata(items)"
+        refresh-action="context.refreshMetadata()">
         <br ng-show="contentExpanded">
-        <div class="context-schemas" ng-show="contentExpanded" ng-repeat="(namespace, predicates) in context.metadataPredicatesByNamespace">
+        <div class="context-schemas" ng-show="contentExpanded && context.metadataPredicatesByNamespace.lengths[namespace] > 0" ng-repeat="(namespace, predicates) in context.metadataPredicatesByNamespace.values">
           <h4 class="context-namespace">
             <span class="context-namespace-label">{{namespace | schemaNamespace: context.schemas}}</span>
             <span class="glyphicon glyphicon-plus clickable" ng-click="context.metadataCollapsedByNamespace[namespace]=false" ng-show="context.metadataCollapsedByNamespace[namespace]"></span>
             <span class="glyphicon glyphicon-minus clickable" ng-click="context.metadataCollapsedByNamespace[namespace]=true" ng-show="!context.metadataCollapsedByNamespace[namespace]"></span>
           </h4>
-          <dl class="dl-horizontal context-metadata" ng-show="!context.metadataCollapsedByNamespace[namespace]" ng-repeat="(predicate, totalTriples) in predicates">
+          <dl class="dl-horizontal context-metadata" ng-show="!context.metadataCollapsedByNamespace[namespace] && totalTriples > 0" ng-repeat="(predicate, totalTriples) in context.metadataPredicatesByNamespace.values[namespace]">
             <dt class="metadata-term">
               <input ng-show="removeListElements && totalTriples > 1" type="checkbox" ng-checked="isPredicateChecked(predicate)" ng-click="checkPredicate(predicate)">
               <a href="{{predicate}}">{{predicate | metadataLabel}}</a>


### PR DESCRIPTION
The structure of the count objects do not delete anything to ensure the scope is never lost for the counts.
A refresh action is needed to ensure that once a change is made, re-calculate all count objects.
The repository view section directive must also handle this refresh behavior.
An additional structure is added so that the totals for a given namespace predicate set can be processed without any additional loops.

By utilizing the $watch on the list object in the repository view section directive, the counts will effectively refreshed as if the broadcast was directly processed.