### PR TITLE
[B-03918] Disallow the changing a schema URL to an invalid value, after schema creation

### DIFF
--- a/src/main/webapp/app/controllers/schemaManagementController.js
+++ b/src/main/webapp/app/controllers/schemaManagementController.js
@@ -10,6 +10,8 @@ cap.controller("SchemaManagementController", function($controller, $scope, $time
   $scope.schemaToEdit = SchemaRepo.getScaffold();
   $scope.schemaToDelete = {};
 
+  $scope.checkNamespaceOnEdit = undefined;
+
   $scope.schemaForms = {
     validations: SchemaRepo.getValidations(),
     getResults: SchemaRepo.getValidationResults
@@ -27,6 +29,7 @@ cap.controller("SchemaManagementController", function($controller, $scope, $time
       }
     }
     $scope.closeModal();
+    $scope.checkNamespaceOnEdit = undefined;
   };
 
   $scope.resetSchemaForms();
@@ -52,6 +55,7 @@ cap.controller("SchemaManagementController", function($controller, $scope, $time
 
   $scope.editSchema = function(schema) {
     $scope.schemaToEdit = schema;
+    $scope.checkNamespaceOnEdit = schema.namespace;
     $scope.openModal('#schemaEditModal');
   };
 
@@ -61,6 +65,16 @@ cap.controller("SchemaManagementController", function($controller, $scope, $time
       $scope.cancelEditSchema();
       $scope.submitClicked = false;
     });
+  };
+
+  $scope.propertiesNeedsLoading = function(schema) {
+    return !($scope.checkNamespaceOnEdit === undefined || $scope.checkNamespaceOnEdit === schema.namespace);
+  }
+
+  $scope.propertiesFound = function(properties) {
+    if (Array.isArray(properties) && properties.length > 0) {
+      $scope.checkNamespaceOnEdit = undefined;
+    }
   };
 
   $scope.cancelEditSchema = function(schema) {

--- a/src/main/webapp/app/controllers/schemaManagementController.js
+++ b/src/main/webapp/app/controllers/schemaManagementController.js
@@ -69,7 +69,7 @@ cap.controller("SchemaManagementController", function($controller, $scope, $time
 
   $scope.propertiesNeedsLoading = function(schema) {
     return !($scope.checkNamespaceOnEdit === undefined || $scope.checkNamespaceOnEdit === schema.namespace);
-  }
+  };
 
   $scope.propertiesFound = function(properties) {
     if (Array.isArray(properties) && properties.length > 0) {

--- a/src/main/webapp/app/directives/findPropertiesDirective.js
+++ b/src/main/webapp/app/directives/findPropertiesDirective.js
@@ -5,6 +5,7 @@ cap.directive("findproperties", function(SchemaRepo) {
         scope: {
             schema: "=",
             mode: "=",
+            found: "=",
         },
         link: function($scope) {
 
@@ -13,7 +14,7 @@ cap.directive("findproperties", function(SchemaRepo) {
             $scope.getProperties = function() {
                 $scope.gettingProperties = true;
                 var getPropertiesPromise = SchemaRepo.findProperties($scope.schema);
-                
+
                 getPropertiesPromise.then(function(res) {
 
                     var un =  $scope.$watch("schema.namespace", function(current, next) {
@@ -26,6 +27,10 @@ cap.directive("findproperties", function(SchemaRepo) {
                     var properties = angular.fromJson(res.body).payload['ArrayList<Property>'];
                     angular.extend($scope.properties, properties);
                     $scope.gettingProperties = false;
+
+                    if ($scope.found) {
+                      $scope.found(properties);
+                    }
                 });
 
                 return getPropertiesPromise;

--- a/src/main/webapp/app/views/modals/schemaEditModal.html
+++ b/src/main/webapp/app/views/modals/schemaEditModal.html
@@ -45,13 +45,13 @@
 
       </div>
       <div class="col-sm-5">
-          <findproperties schema="schemaToEdit" mode="'edit'"></findproperties>
+          <findproperties schema="schemaToEdit" mode="'edit'" found="propertiesFound"></findproperties>
       </div>
     </div>
 
   </div>
   <div class="modal-footer">
     <button type="button" class="btn" ng-class="{'btn-default': schemaForms.edit.$pristine, 'btn-warning': !schemaForms.edit.$pristine}" ng-click="cancelEditSchema()">Cancel</button>
-    <button type="submit" class="btn btn-success" ng-disabled="schemaForms.edit.$invalid || submitClicked">Update</button>
+    <button type="submit" class="btn btn-success" ng-disabled="schemaForms.edit.$invalid || submitClicked || propertiesNeedsLoading(schemaToEdit)">Update</button>
   </div>
 </form>


### PR DESCRIPTION
This approach to solving the problem relies on modifying CAPs FindPropertiesDirective and the submit button on the edit.

Instead of some sort of ng-change/ng-blur on the weaver ValidatedInputDirective, this adds a function call `propertiesNeedsLoading` on the submit button.