### PR TITLE
Added rem rule to html and lato font

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -21,6 +21,8 @@
 
   <meta name="description" content="Fedora User Interface" />
 
+  <link href='http://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+
   <link rel="stylesheet" th:href="${@environment.getProperty('app.url')+'/wro/app.css'}" />
 
 </head>

--- a/src/main/webapp/app/resources/styles/sass/app.scss
+++ b/src/main/webapp/app/resources/styles/sass/app.scss
@@ -14,10 +14,11 @@
 
 html {
   height: 100%;
+  font-size: 1rem;
 }
 
 body {
-  font-family: Arial, Helvetica, Sans-Serif;
+  font-family: "Lato", sans-serif;
   opacity: 0;
   min-height: 100%;
   display: grid;


### PR DESCRIPTION
# Description

This PR addresses the following two issues:
Inconsistent sizing from bootstrap classes between SAGE and the Library main site. 
Lato font.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X ] Visual Confirmation
- [ X] Used browser inspector tools.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

